### PR TITLE
added physics_layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ That's it! I hope you've got ideas of what you'd like to share with others.
 |[Inflector](addons/godot-next/references/inflector.gd)|A vocabulary wrapper of inflection tools to pluralize and singularize strings.|GDScript
 |[InspectorControls](addons/godot-next/global/inspector_controls.gd)|A utility for creating data-editing GUI elements.|GDScript
 |[MessageDispatcher](addons/godot-next/objects/message_dispatcher.gd)|A base object that handles signaling for non predetermined signals.|GDScript
-|[PhysicsLayers](addons/godot-next/global/physics_layers.gd)|A Utility class which allows easy access to your physics layers via their names in the project settings.
+|[PhysicsLayers](addons/godot-next/global/physics_layers.gd)|A Utility class which allows easy access to your physics layers via their names in the project settings.|GDScript
 |[ProjectTools](addons/godot-next/global/project_tools.gd)|A utility for any features useful in the context of a Godot Project.|GDScript
 |[PropertyInfo](addons/godot-next/references/property_info.gd)|A wrapper and utility class for generating PropertyInfo Dictionaries, for use in `Object._get_property_list()`.|GDScript
 |[ResourceArray](addons/godot-next/resources/resource_collections/resource_array.gd)|A ResourceCollection implementation that manages an Array of Resources.|GDScript

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ That's it! I hope you've got ideas of what you'd like to share with others.
 |[Inflector](addons/godot-next/references/inflector.gd)|A vocabulary wrapper of inflection tools to pluralize and singularize strings.|GDScript
 |[InspectorControls](addons/godot-next/global/inspector_controls.gd)|A utility for creating data-editing GUI elements.|GDScript
 |[MessageDispatcher](addons/godot-next/objects/message_dispatcher.gd)|A base object that handles signaling for non predetermined signals.|GDScript
+|[PhysicsLayers](addons/godot-next/global/physics_layers.gd)|A Utility class which allows easy access to your physics layers via their names in the project settings.
 |[ProjectTools](addons/godot-next/global/project_tools.gd)|A utility for any features useful in the context of a Godot Project.|GDScript
 |[PropertyInfo](addons/godot-next/references/property_info.gd)|A wrapper and utility class for generating PropertyInfo Dictionaries, for use in `Object._get_property_list()`.|GDScript
 |[ResourceArray](addons/godot-next/resources/resource_collections/resource_array.gd)|A ResourceCollection implementation that manages an Array of Resources.|GDScript

--- a/addons/godot-next/global/physics_layers.gd
+++ b/addons/godot-next/global/physics_layers.gd
@@ -3,57 +3,53 @@
 # license: MIT
 # description: A Utility class which allows easy access to your physics layers via their names in the project settings.
 tool
-extends Node
+extends Resource
 
 class_name PhysicsLayers
 
-const _PHYSICS_LAYERS_BIT : Dictionary = {}
-const _PHYSICS_2D_PREFIX = "2d_physics"
-const _PHYSICS_3D_PREFIX = "3d_physics"
+const Physics2D : int = 0
+const Physics3D : int = 1
 
-#Preload all the layer names in a cache
-static func setup():
-  for prefix in [_PHYSICS_2D_PREFIX, _PHYSICS_3D_PREFIX]:
-    var path = "layer_names/".plus_file(prefix) 
-    for i in range(1, 21):
-      var layer_path = path.plus_file(str("layer_", i))     
-      var layer_name = ProjectSettings.get(layer_path)
-      
-      if(not layer_name): 
-        layer_name = str("Layer ", i)
-      
-      var layer_key = prefix.plus_file(layer_name)
-        
-      _PHYSICS_LAYERS_BIT[layer_key] = i-1
+const _PHYSICS_LAYERS_BIT : Dictionary = {}
+const _PHYSICS_2D_PREFIX : String = "2d_physics"
+const _PHYSICS_3D_PREFIX : String = "3d_physics"
+
+static func setup() -> void:
+    for prefix in [_PHYSICS_2D_PREFIX, _PHYSICS_3D_PREFIX]:
+        var path : String = "layer_names/".plus_file(prefix) 
+        for i in range(1, 21):
+          var layer_path : String = path.plus_file(str("layer_", i))     
+          var layer_name : String = ProjectSettings.get(layer_path)
+
+          if(not layer_name): 
+            layer_name = str("Layer ", i)
+
+          var layer_key : String = prefix.plus_file(layer_name)
+
+          _PHYSICS_LAYERS_BIT[layer_key] = i-1
 
 # Get the corresponding bit of the layer named <layer_name>
-static func _get_physics_layer_bit(layer_name: String) -> int:
-  if not _PHYSICS_LAYERS_BIT.has(layer_name):
-    setup()
+static func _get_physics_layer_index(layer_name: String) -> int:
+    if not _PHYSICS_LAYERS_BIT.has(layer_name):
+        setup()
   
-  assert _PHYSICS_LAYERS_BIT.has(layer_name)  
-  return _PHYSICS_LAYERS_BIT[layer_name]
+    assert (_PHYSICS_LAYERS_BIT.has(layer_name))
+    return _PHYSICS_LAYERS_BIT[layer_name]
       
-# Get the corresponding bit of the 2d layer named <layer_name>
-static func get_physics_layer_bit_2d(layer_name: String) -> int:
-  return _get_physics_layer_bit( _PHYSICS_2D_PREFIX.plus_file(layer_name))
-
-# Get the corresponding bit of the 3d layer named <layer_name>
-static func get_physics_layer_bit_3d(layer_name: String) -> int:
-  return _get_physics_layer_bit( _PHYSICS_3D_PREFIX.plus_file(layer_name))
-
 # Get the layer that corresponds to to the combination of all the passed layer names. 
-static func get_physics_layer_2d(layer_names: Array) -> int:
-  var res : int  = 0
-  for i in range(0, layer_names.size()):
-    var layer_bit = get_physics_layer_bit_2d(layer_names[i])
-    res |= 1 << layer_bit
-  return res
+static func get_physics_layer(layer_names: Array, layer_type : int = Physics2D) -> int:
+    var res : int  = 0
+    for i in range(layer_names.size()):
+        var layer_bit : int = get_physics_layer_index(layer_names[i], layer_type)
+        res |= 1 << layer_bit
+    return res
 
-# Get the layer that corresponds to to the combination of all the passed layer names. 
-static func get_physics_layer_3d(layer_names: Array) -> int:
-  var res : int  = 0
-  for i in range(0, layer_names.size()):
-    var layer_bit = get_physics_layer_bit_3d(layer_names[i])
-    res |= 1 << layer_bit
-  return res
+static func get_physics_layer_index(layer_name: String, layer_type : int = Physics2D) -> int:
+    var res : int
+    match layer_type:
+        Physics2D:
+            res = _get_physics_layer_index(_PHYSICS_2D_PREFIX.plus_file(layer_name))
+        Physics3D:
+            res = _get_physics_layer_index(_PHYSICS_3D_PREFIX.plus_file(layer_name))
+    
+    return res

--- a/addons/godot-next/global/physics_layers.gd
+++ b/addons/godot-next/global/physics_layers.gd
@@ -1,0 +1,59 @@
+# PhysicsLayers
+# author: xaguzman
+# license: MIT
+# description: A Utility class which allows easy access to your physics layers via their names in the project settings.
+tool
+extends Node
+
+class_name PhysicsLayers
+
+const _PHYSICS_LAYERS_BIT : Dictionary = {}
+const _PHYSICS_2D_PREFIX = "2d_physics"
+const _PHYSICS_3D_PREFIX = "3d_physics"
+
+#Preload all the layer names in a cache
+static func setup():
+  for prefix in [_PHYSICS_2D_PREFIX, _PHYSICS_3D_PREFIX]:
+    var path = "layer_names/".plus_file(prefix) 
+    for i in range(1, 21):
+      var layer_path = path.plus_file(str("layer_", i))     
+      var layer_name = ProjectSettings.get(layer_path)
+      
+      if(not layer_name): 
+        layer_name = str("Layer ", i)
+      
+      var layer_key = prefix.plus_file(layer_name)
+        
+      _PHYSICS_LAYERS_BIT[layer_key] = i-1
+
+# Get the corresponding bit of the layer named <layer_name>
+static func _get_physics_layer_bit(layer_name: String) -> int:
+  if not _PHYSICS_LAYERS_BIT.has(layer_name):
+    setup()
+  
+  assert _PHYSICS_LAYERS_BIT.has(layer_name)  
+  return _PHYSICS_LAYERS_BIT[layer_name]
+      
+# Get the corresponding bit of the 2d layer named <layer_name>
+static func get_physics_layer_bit_2d(layer_name: String) -> int:
+  return _get_physics_layer_bit( _PHYSICS_2D_PREFIX.plus_file(layer_name))
+
+# Get the corresponding bit of the 3d layer named <layer_name>
+static func get_physics_layer_bit_3d(layer_name: String) -> int:
+  return _get_physics_layer_bit( _PHYSICS_3D_PREFIX.plus_file(layer_name))
+
+# Get the layer that corresponds to to the combination of all the passed layer names. 
+static func get_physics_layer_2d(layer_names: Array) -> int:
+  var res : int  = 0
+  for i in range(0, layer_names.size()):
+    var layer_bit = get_physics_layer_bit_2d(layer_names[i])
+    res |= 1 << layer_bit
+  return res
+
+# Get the layer that corresponds to to the combination of all the passed layer names. 
+static func get_physics_layer_3d(layer_names: Array) -> int:
+  var res : int  = 0
+  for i in range(0, layer_names.size()):
+    var layer_bit = get_physics_layer_bit_3d(layer_names[i])
+    res |= 1 << layer_bit
+  return res


### PR DESCRIPTION
Correction of pull request #40 

### Latest Comment:
I made it a Node rather than a Resource since accessing the methods would keep throwing "Script does not inherit a Node" error, and while it works, I don't really like having errors or warnings.

I had the author set incorrectly :| so I fixed it
Had some troubles to fix it so had force-push. 

To test the new physics_layers script I added a "props" layer in both, 2d and 3d physics layers ( as layer 1 in 2d, and as layer2 in 3d).

I created a Scene and added a script, and just added some calls in the _ready():

```
func _ready():
  var bit2d = PhysicsLayers.get_physics_layer_bit_2d("props")
  var bit3d = PhysicsLayers.get_physics_layer_bit_3d("props")
  print ("Props layer 2d bit: %s" % bit2d )
  print ("Props layer 3d bit: %s" % bit3d )
```