### PR TITLE
Use the setter to change the path

### DIFF
--- a/addons/godot-next/2d/trail_2d.gd
+++ b/addons/godot-next/2d/trail_2d.gd
@@ -132,7 +132,7 @@ func erase_trail():
 func set_target(p_value: Node2D):
 	if p_value:
 		if get_path_to(p_value) != target_path:
-			target_path = get_path_to(p_value)
+			set_target_path(get_path_to(p_value))
 	else:
 		target_path = @""
 


### PR DESCRIPTION
As it's within the class, setget doesn't work, and target won't be set, so we should use the setter explicitly