### PR TITLE
Add DebugLabel node

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ That's it! I hope you've got ideas of what you'd like to share with others.
 |[ClassType](addons/godot-next/references/class_type.gd)|A class abstraction, both for engine and user-defined types.|GDScript
 |[CSVFile](addons/godot-next/references/csv_file.gd)|Similar to ConfigFile, parses a .csv file. Can generate a key-value store from rows. Supports .tsv files.|GDScript
 |[Cycle](addons/godot-next/gui/cycle.gd)|Cycles through child nodes without any visibility or container effects.|GDScript
+|[DebugLabel](addons/godot-next/gui/debug_label.gd)|A label which displays a list of property values in any `Object`-derived instance at run-time for debugging purposes.|GDScript
 |[EditorTools](addons/godot-next/global/editor_tools.gd)|A utility for any features useful in the context of the Editor.|GDScript
 |[FileSearch](addons/godot-next/global/file_search.gd)|A utility with helpful methods to search through one's project files (or any directory).|GDScript
 |[FileSystemLink](addons/godot-next/global/file_system_link.gd)|A utility for creating links (file/directory, symbolic/hard).|GDScript

--- a/addons/godot-next/gui/debug_label.gd
+++ b/addons/godot-next/gui/debug_label.gd
@@ -1,0 +1,161 @@
+tool
+extends Label
+class_name DebugLabel
+# author: Xrayez
+# license: MIT
+# description: A label which displays a list of property values in any Object
+#              instance, suitable for both in-game and editor debugging.
+# usage:
+#     var debug_label = DebugLabel.new(node)
+#     debug_label.watchv(["position:x", "scale", "rotation"])
+#
+# todo: Use RichTextLabel or custom drawing for color coding of core data types.
+#       Unfortunately, it doesn't compute its minimum size the same way as a Label
+
+# Assign a node via inspector. If empty, a parent node is inspected instead.
+export var target_path := NodePath() setget set_target_path
+
+# Inspected object, not restricted to "Node" type, may be assigned via code.
+var target: Object
+
+export var show_label_name := false
+export var show_target_name := false
+
+# A list of property names to be inspected and printed in the `target`.
+# Use indexed syntax (:) to access nested properties: "position:x".
+# Indexing will also work with any `onready` vars defined via script.
+# These can be set beforehand via inspector or via code with "watch()".
+export var properties := PoolStringArray()
+
+# Advanced: depending on the properties inspected, you may need to switch
+# to either "IDLE" or "PHYSICS" update mode to avoid thread issues.
+enum UpdateMode {
+	IDLE,
+	PHYSICS,
+	MANUAL
+}
+export(UpdateMode) var update_mode = UpdateMode.IDLE setget set_update_mode
+
+
+func _init(p_target: Object = null) -> void:
+	if p_target != null:
+		target = p_target
+
+# 	# TODO: RichTextLabel relevant overrides
+#	rect_clip_content = false
+#	scroll_active = false
+#	selection_enabled = true
+
+
+func _enter_tree() -> void:
+	set_process_internal(true)
+
+	if not OS.is_debug_build():
+		text = ""
+		hide()
+		return
+	if target == null:
+		if not target_path.is_empty():
+			_update_target_from_path()
+		else:
+			target = get_parent()
+
+
+func _exit_tree() -> void:
+	set_process_internal(false)
+	set_physics_process_internal(false)
+
+	target = null
+
+
+func set_target_path(p_path: NodePath) -> void:
+	target_path = p_path
+	call_deferred("_update_target_from_path")
+
+
+func set_update_mode(p_mode: int) -> void:
+	update_mode = p_mode
+
+	match update_mode:
+		UpdateMode.IDLE:
+			set_process_internal(true)
+			set_physics_process_internal(false)
+		UpdateMode.PHYSICS:
+			set_process_internal(false)
+			set_physics_process_internal(true)
+		UpdateMode.MANUAL:
+			set_process_internal(false)
+			set_physics_process_internal(false)
+
+
+func _notification(what: int) -> void:
+	# Using internal processing as it guarantees that
+	# debug info is updated even if the scene tree is paused.
+	match what:
+		NOTIFICATION_INTERNAL_PROCESS:
+			_update_debug_info()
+		NOTIFICATION_INTERNAL_PHYSICS_PROCESS:
+			_update_debug_info()
+
+
+func _update_target_from_path() -> void:
+	if has_node(target_path):
+		target = get_node(target_path)
+	# target = get_node_or_null(target_path) # 3.2
+
+	
+func watch(p_what: String) -> void:
+	properties = PoolStringArray([p_what])
+	
+	
+func watchv(p_what: PoolStringArray) -> void:
+	properties = p_what
+	
+	
+func watch_append(p_what: String) -> void:
+	properties.append(p_what)
+	
+	
+func watch_appendv(p_what: PoolStringArray) -> void:
+	properties.append_array(p_what)
+
+
+func clear() -> void:
+	properties = PoolStringArray()
+
+
+func _update_debug_info() -> void:
+	if not OS.is_debug_build():
+		return
+
+	text = ""
+
+	if not is_instance_valid(target):
+		text = "null"
+		return
+
+	if show_label_name:
+		text += "%s\n" % [name]
+
+	if show_target_name:
+		var object_name := String()
+
+		if target is Node:
+			object_name = target.name
+		elif target is Resource:
+			object_name = target.resource_name
+
+		if not object_name.empty():
+			text += "%s\n" % [object_name]
+
+	for prop in properties:
+		if prop.empty():
+			continue
+		var var_str = var2str(target.get_indexed(prop))
+		text += "%s = %s\n" % [prop, var_str]
+
+
+func update() -> void:
+	# Have to be called manually if operating in UpdateMode.MANUAL
+	_update_debug_info()
+	.update()


### PR DESCRIPTION
Helps godotengine/godot-proposals#115.

A label which displays a list of property values in any `Object` instance, suitable for both in-game and editor debugging of nodes.

The implementation is fairly straightforward. I've done some attempts on color coding variant types with `RichTextLabel` but there are usability issues with having to set minimum size manually for each label for the contents to be displayed.

Re-implementing the internal `Label` functionality just to achieve this seamless display of text with custom colors seems like an arduous task to do via script currently. Even if one manages to draw stuff with `font.draw_char` or `draw_string`, there are still many aspects to account like font character spacing, line spacing etc. `var2str` is used over `String()` conversion which converts any Variant to text in a consistent way at least (and can even be parsed back with `str2var` if you manage to copy-paste the debug label contents, which is possible in `RichTextLabel` btw).

Works in 3.1 and 3.2.

## Test project
[godot-debug-label.zip](https://github.com/godot-extended-libraries/godot-next/files/3936573/godot-debug-label.zip)
