### PR TITLE
Added the DiscreteGradientTexture

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ That's it! I hope you've got ideas of what you'd like to share with others.
 |[Trail3D](addons/godot-next/3d/trail_3d.gd)|Creates a variable-length trail on an ImmediateGeometry node.|GDScript
 |[Variant](addons/godot-next/global/variant.gd)|A utility class for handling Variants (the type wrapper for all variables in Godot's scripting API).|GDScript
 |[VBoxItemList](addons/godot-next/gui/v_box_item_list.gd)|Creates a vertical list of items that can be added or removed. Items are a user-specified Script or Scene Control.|GDScript
+|[DiscreteGradientTexture](addons/godot-next/resources/DiscreteGradientTexture.gd)|Creates a not interpolated texture for a gradient.|GDScript

--- a/addons/godot-next/resources/DiscreteGradientTexture.gd
+++ b/addons/godot-next/resources/DiscreteGradientTexture.gd
@@ -1,0 +1,78 @@
+# DiscreteGradientTexture
+# author: Athrunen
+# license: MIT
+# description: Has the same functionality as the GradientTexture but does not interpolate colors.
+# todos:
+# - Write a more elegant way of updating the texture than changing the resolution
+# - Persuade godot to repeat the texture vertically in the inspector
+tool
+extends ImageTexture
+class_name DiscreteGradientTexture
+
+##### CLASSES #####
+
+##### SIGNALS #####
+
+##### CONSTANTS #####
+
+##### PROPERTIES #####
+
+export var resolution : int = 256 setget _update_resolution 
+export var gradient : Gradient = Gradient.new() setget _update_gradient
+
+##### NOTIFICATIONS #####
+
+func _ready() -> void:
+	_update_texture()
+
+##### OVERRIDES #####
+
+##### VIRTUALS #####
+
+##### PUBLIC METHODS #####
+
+##### PRIVATE METHODS #####
+
+func _update_texture() -> void:
+	var image := Image.new()
+	image.create(resolution, 1, false, Image.FORMAT_RGBA8)
+	
+	if (not gradient):
+		return
+	
+	image.lock()
+	
+	var last_offset := 0
+	var last_pixel := 0
+	var index := 0
+	for offset in gradient.offsets:
+		var amount := int(round((offset - last_offset) * resolution))
+		amount -= 1 if amount > 0 else 0
+		var color := gradient.colors[index]
+		for x in range(amount):
+			image.set_pixel(x + last_pixel, 0, color)
+		
+		last_offset = offset
+		last_pixel = last_pixel + amount
+		index += 1
+	
+	if last_pixel < resolution:
+		var color := gradient.colors[-1]
+		for x in resolution - last_pixel:
+			image.set_pixel(x + last_pixel, 0, color)
+	 
+	image.unlock()
+	self.create_from_image(image, 0)
+
+##### CONNECTIONS #####
+
+##### SETTERS AND GETTERS #####
+
+func _update_gradient(g: Gradient) -> void:
+	gradient = g
+	_update_texture()
+
+
+func _update_resolution(r: int) -> void:
+	resolution = r
+	_update_texture()

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -47,3 +47,6 @@
     - MessageDispatcher
     - Allows any object to register a function that handles a specific message_type.
     - Emit a message on the dispatcher and it sends it to all relevant handlers or discards it if no handlers were registered.
+7. Have you ever wanted to create a flat gradient with hard transitions?
+	- DiscreteGradientTexture
+	- It works like the GradientTexture but ignores the color interpolation of the gradient.


### PR DESCRIPTION
Just a simple script to create a discrete texture from a gradient. I do just fill the color of the offset in from the right to the left, ignoring any interpolation.

It works exactly like the normal GradientTexture resource, set a gradient and a width and have fun.

It could be used, for example, to create a color map for toon shading.