### PR TITLE
Add icon for Geometry2D

### DIFF
--- a/addons/godot-next/2d/geometry_2d.gd
+++ b/addons/godot-next/2d/geometry_2d.gd
@@ -7,7 +7,7 @@
 #	  to use it as its CollisionShape2D.
 tool
 extends CollisionShape2D
-class_name Geometry2D
+class_name Geometry2D, "../icons/icon_geometry_2d.svg"
 
 ##### CLASSES #####
 

--- a/addons/godot-next/icons/icon_geometry_2d.svg
+++ b/addons/godot-next/icons/icon_geometry_2d.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m14 1050.4h-12v-12h12z" fill="none" stroke="#a5b7f3" stroke-linejoin="round" stroke-opacity=".98824" stroke-width="2" transform="translate(0 -1036.4)"/><path d="m4 4h8v8h-8z" fill="#a5b7f3" fill-opacity=".988235"/></svg>

--- a/addons/godot-next/icons/icon_geometry_2d.svg.import
+++ b/addons/godot-next/icons/icon_geometry_2d.svg.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/icon_geometry_2d.svg-3e8b75bb6a38693255a76162660a3237.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/godot-next/icons/icon_geometry_2d.svg"
+dest_files=[ "res://.import/icon_geometry_2d.svg-3e8b75bb6a38693255a76162660a3237.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0


### PR DESCRIPTION
It's the CollisionShape2D icon, but filled in.

![icon_geometry_2d](https://user-images.githubusercontent.com/1646875/80300109-d26d9680-8767-11ea-9683-ad62bc47ecf0.png)
