### PR TITLE
Change all scripts to conform to the GDScript style guide

### DIFF
--- a/addons/godot-next/2d/geometry_2d.gd
+++ b/addons/godot-next/2d/geometry_2d.gd
@@ -1,26 +1,15 @@
-# Geometry2D
+tool
+class_name Geometry2D, "../icons/icon_geometry_2d.svg"
+extends CollisionShape2D
 # author: Henrique "Pigdev" Campos
 # license: MIT
 # description: Draws a Shape2D using CollisionShape2D's editor plugin handles.
 # notes:
 #	- Don't use it as direct child of CollisionBody2D classes unless you intent
 #	  to use it as its CollisionShape2D.
-tool
-extends CollisionShape2D
-class_name Geometry2D, "../icons/icon_geometry_2d.svg"
 
-##### CLASSES #####
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
-
-##### PROPERTIES #####
-
-export (Color) var color := Color(1, 1, 1, 1) setget set_color
-export (Vector2) var offset_position := Vector2(0, 0) setget set_offset
-
-##### NOTIFICATIONS #####
+export (Color) var color := Color.white setget set_color
+export (Vector2) var offset_position := Vector2.ZERO setget set_offset
 
 func _draw() -> void:
 	if shape is CircleShape2D:
@@ -31,11 +20,6 @@ func _draw() -> void:
 	elif shape is CapsuleShape2D:
 		draw_capsule(offset_position, shape.radius, shape.height, color)
 
-##### OVERRIDES #####
-
-##### VIRTUALS #####
-
-##### PUBLIC METHODS #####
 
 func draw_capsule(capsule_position: Vector2, capsule_radius: float,
 		capsule_height: float, capsule_color: Color) -> void:
@@ -50,11 +34,6 @@ func draw_capsule(capsule_position: Vector2, capsule_radius: float,
 	var rect := Rect2(rect_position, Vector2(capsule_radius * 2, capsule_height))
 	draw_rect(rect, capsule_color)
 
-##### PRIVATE METHODS #####
-
-##### CONNECTIONS #####
-
-##### SETTERS AND GETTERS #####
 
 func set_color(new_color: Color) -> void:
 	color = new_color

--- a/addons/godot-next/2d/trail_2d.gd
+++ b/addons/godot-next/2d/trail_2d.gd
@@ -1,4 +1,5 @@
-# Trail2D
+class_name Trail2D, "../icons/icon_trail_2d.svg"
+extends Line2D
 # author: willnationsdev
 # brief description: Creates a variable-length trail that tracks the "target" node.
 # API details:
@@ -18,45 +19,34 @@
 #				- use `bool _should_shrink()` to return under what conditions
 #				  the degen_rate should be removed from the trail's list of points.
 
-extends Line2D
-class_name Trail2D, "../icons/icon_trail_2d.svg"
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
-
 enum Persistence {
 	OFF,         # Do not persist. Remove all points after the trail_length.
-	ALWAYS,	     # Always persist. Do not remove any points.
+	ALWAYS,      # Always persist. Do not remove any points.
 	CONDITIONAL, # Sometimes persist. Choose an algorithm for when to add and remove points.
 }
 
 enum PersistWhen {
 	ON_MOVEMENT, # Add points during movement and remove points when not moving.
-	CUSTOM,	     # Override _should_grow() and _should_shrink() to define when to add/remove points.
+	CUSTOM,      # Override _should_grow() and _should_shrink() to define when to add/remove points.
 }
 
-##### PROPERTIES #####
-
-# The target node to track
-var target: Node2D setget set_target
-
-# The NodePath to the target
+# The NodePath to the target.
 export var target_path: NodePath = @".." setget set_target_path
-# If not persisting, the number of points that should be allowed in the trail
+# If not persisting, the number of points that should be allowed in the trail.
 export var trail_length: int = 10
 # To what degree the trail should remain in existence before automatically removing points.
 export(int, "Off", "Always", "Conditional") var persistence: int = Persistence.OFF
-# During conditional persistence, which persistence algorithm to use
+# During conditional persistence, which persistence algorithm to use.
 export(int, "On Movement", "Custom") var persistence_condition: int = PersistWhen.ON_MOVEMENT
-# During conditional persistence, how many points to remove per frame
+# During conditional persistence, how many points to remove per frame.
 export var degen_rate: int = 1
-# If true, automatically set z_index to be one less than the 'target'
+# If true, automatically set z_index to be one less than the 'target'.
 export var auto_z_index: bool = true
-# If true, will automatically setup a gradient for a gradually transparent trail
+# If true, will automatically setup a gradient for a gradually transparent trail.
 export var auto_alpha_gradient: bool = true
 
-##### NOTIFICATIONS #####
+# The target node to track.
+var target: Node2D setget set_target
 
 func _init():
 	set_as_toplevel(true)
@@ -109,27 +99,12 @@ func _process(_delta: float):
 							for i in range(degen_rate):
 								remove_point(0)
 
-##### OVERRIDES #####
-
-##### VIRTUAL METHODS #####
-
-func _should_grow() -> bool:
-	return true
-
-
-func _should_shrink() -> bool:
-	return true
-
-##### PUBLIC METHODS #####
 
 func erase_trail():
 	#warning-ignore:unused_variable
 	for i in range(get_point_count()):
 		remove_point(0)
 
-##### PRIVATE METHODS #####
-
-##### SETTERS AND GETTERS #####
 
 func set_target(p_value: Node2D):
 	if p_value:
@@ -142,3 +117,11 @@ func set_target(p_value: Node2D):
 func set_target_path(p_value: NodePath):
 	target_path = p_value
 	target = get_node(p_value) as Node2D if has_node(p_value) else null
+
+
+func _should_grow() -> bool:
+	return true
+
+
+func _should_shrink() -> bool:
+	return true

--- a/addons/godot-next/3d/trail_3d.gd
+++ b/addons/godot-next/3d/trail_3d.gd
@@ -1,4 +1,5 @@
-# Trail3D
+class_name Trail3D, "../icons/icon_trail_3d.svg"
+extends ImmediateGeometry
 # author: miziziziz
 # brief description: Creates a variable-length trail on an ImmediateGeometry node.
 # API details:
@@ -6,14 +7,12 @@
 #	- density_around: number of vertexes in each loop
 #	- shape: curve used to shape trail, right click on this in inspector to see curve options
 
-extends ImmediateGeometry
-class_name Trail3D, "../icons/icon_trail_3d.svg"
-
 export(float) var length = 10.0
 export var max_radius = 0.5
 export(int) var density_lengthwise = 25
 export(int) var density_around = 5
 export(float, EASE) var shape
+
 var points = []
 var segment_length = 1.0
 
@@ -62,25 +61,28 @@ func render_trail():
 	var ind = 0
 	var first_iteration = true
 	var last_first_vec = Vector3()
-	# create vertex loops around points
+	# Create vertex loops around points.
 	for p in local_points:
 		var new_last_points = []
 		var offset = last_p - p
 		if offset == Vector3():
 			continue
-		var y_vec = offset.normalized() # get vector pointing from this point to last point
+		# Get vector pointing from this point to last point.
+		var y_vec = offset.normalized()
 		var x_vec = Vector3()
 		if first_iteration:
-			x_vec = y_vec.cross(y_vec.rotated(Vector3(1, 0, 0), 0.3)) #cross product with random vector to get a perpendicular vector
+			# Cross product with random vector to get a perpendicular vector.
+			x_vec = y_vec.cross(y_vec.rotated(Vector3.RIGHT, 0.3))
 		else:
-			x_vec = y_vec.cross(last_first_vec).cross(y_vec).normalized() # keep each loop at the same rotation as the previous
+			# Keep each loop at the same rotation as the previous.
+			x_vec = y_vec.cross(last_first_vec).cross(y_vec).normalized()
 		var width = max_radius
 		if shape != 0:
 			width = (1 - ease((ind + 1.0) / density_lengthwise, shape)) * max_radius
 		var seg_verts = []
 		var f_iter = true
-		for i in range(density_around): # set up row of verts for each level
-			var new_vert = p + width * x_vec.rotated(y_vec, i * 2 * PI / density_around).normalized()
+		for i in range(density_around): # Set up row of verts for each level.
+			var new_vert = p + width * x_vec.rotated(y_vec, i * TAU / density_around).normalized()
 			if f_iter:
 				last_first_vec = new_vert - p
 				f_iter = false
@@ -89,14 +91,14 @@ func render_trail():
 		last_p = p
 		ind += 1
 		first_iteration = false
-		
-	# create tris
+	
+	# Create tris.
 	for j in range(len(verts) - 1):
 		var cur = verts[j]
 		var nxt = verts[j + 1]
 		for i in range(density_around):
 			var nxt_i = (i + 1) % density_around
-			#order added affects normal
+			# Order added affects normal.
 			add_vertex(cur[i])
 			add_vertex(cur[nxt_i])
 			add_vertex(nxt[i])
@@ -105,15 +107,14 @@ func render_trail():
 			add_vertex(nxt[i])
 	
 	if verts.size() > 1:
-		#cap off top
+		# Cap off top.
 		for i in range(density_around):
 			var nxt = (i + 1) % density_around
 			add_vertex(verts[0][i])
 			add_vertex(Vector3())
 			add_vertex(verts[0][nxt])
 		
-		
-		#cap off bottom
+		# Cap off bottom.
 		for i in range(density_around):
 			var nxt = (i + 1) % density_around
 			add_vertex(verts[verts.size() - 1][i])

--- a/addons/godot-next/global/editor_tools.gd
+++ b/addons/godot-next/global/editor_tools.gd
@@ -1,9 +1,8 @@
-# EditorTools
-# author: willnationsdev
-# description: A utility for any features useful in the context of the Editor
 tool
-extends Reference
 class_name EditorTools
+extends Reference
+# author: willnationsdev
+# description: A utility for any features useful in the context of the Editor.
 
 static func is_in_edited_scene(p_node: Node):
 	if not p_node.is_inside_tree():

--- a/addons/godot-next/global/file_search.gd
+++ b/addons/godot-next/global/file_search.gd
@@ -1,42 +1,34 @@
-# FileSearch
+tool
+class_name FileSearch
+extends Reference
 # author: willnationsdev
 # license: MIT
 # description: A utility with helpful methods to search through one's project files (or any directory).
-tool
-extends Reference
-class_name FileSearch
 
-##### CLASSES #####
-
-class FileEvaluator:
-	extends Reference
-	
-	##### PROPERTIES #####
-
+class FileEvaluator extends Reference:
 	var file_path: String = "" setget set_file_path
-	
-	##### virtuals #####
 
-	# _is_match() -> void: assigns a new file path to the object
+	# Assigns a new file path to the object.
 	func _is_match() -> bool:
 		return true
-
-	# _get_key() -> void: If _is_match() returns true, returns the key used to store the data.
+	
+	
+	# If _is_match() returns true, returns the key used to store the data.
 	func _get_key():
 		return file_path
 	
-	# _get_value() -> Dictionary: If _is_match() returns true, returns the data associated with the file.
+	
+	# If _is_match() returns true, returns the data associated with the file.
 	func _get_value() -> Dictionary:
 		return { "path": file_path }
 	
-	# set_file_path(path) -> void: assigns a new file path to the object
+	
+	# Assigns a new file path to the object.
 	func set_file_path(p_value):
 		file_path = p_value
 
 
-class FilesThatHaveString:
-	extends FileEvaluator
-	
+class FilesThatHaveString extends FileEvaluator:
 	var _compare: String
 	
 	func _init(p_compare: String = ""):
@@ -47,9 +39,7 @@ class FilesThatHaveString:
 		return file_path.find(_compare) != -1
 
 
-class FilesThatAreSubsequenceOf:
-	extends FileEvaluator
-
+class FilesThatAreSubsequenceOf extends FileEvaluator:
 	var _compare: String
 	var _case_sensitive: bool
 
@@ -57,15 +47,14 @@ class FilesThatAreSubsequenceOf:
 		_compare = p_compare
 		_case_sensitive = p_case_sensitive
 	
+	
 	func _is_match() -> bool:
 		if _case_sensitive:
 			return _compare.is_subsequence_of(file_path)
 		return _compare.is_subsequence_ofi(file_path)
 
 
-class FilesThatMatchRegex:
-	extends FileEvaluator
-
+class FilesThatMatchRegex extends FileEvaluator:
 	var _regex: RegEx = RegEx.new()
 	var _compare_full_path
 	var _match: RegExMatch = null
@@ -90,9 +79,7 @@ class FilesThatMatchRegex:
 		return data
 
 
-class FilesThatExtendResource:
-	extends FileEvaluator
-	
+class FilesThatExtendResource extends FileEvaluator:
 	var _match_func: FuncRef
 	var _exts: Dictionary
 	
@@ -116,19 +103,8 @@ class FilesThatExtendResource:
 				return true
 		return false
 
-##### SIGNALS #####
-
-##### CONSTANTS #####
 
 const SELF_PATH: String = "res://addons/godot-next/global/file_search.gd"
-
-##### NOTIFICATIONS #####
-
-##### VIRTUALS #####
-
-##### OVERRIDES #####
-
-##### PUBLIC METHODS #####
 
 static func search_string(p_str: String, p_from_dir: String = "res://", p_recursive: bool = true) -> Dictionary:
 	return _search(FilesThatHaveString.new(p_str), p_from_dir, p_recursive)
@@ -165,10 +141,10 @@ static func search_types(p_match_func: FuncRef = null, p_from_dir: String = "res
 static func search_resources(p_types: PoolStringArray = ["Resource"], p_match_func: FuncRef = null, p_from_dir: String = "res://", p_recursive: bool = true) -> Dictionary:
 	return _search(FilesThatExtendResource.new(p_types, p_match_func), p_from_dir, p_recursive)
 
-##### PRIVATE METHODS #####
 
 static func _this() -> Script:
 	return load(SELF_PATH) as Script
+
 
 # p_evaluator: A FileEvaluator type.
 # p_from_dir: The starting location from which to scan.
@@ -180,7 +156,7 @@ static func _search(p_evaluator: FileEvaluator, p_from_dir: String = "res://", p
 	var data: Dictionary = {}
 	var eval: FileEvaluator = p_evaluator
 
-	# generate 'data' map
+	# Generate 'data' map.
 	while not dirs.empty():
 		var dir_name = dirs.back()
 		dirs.pop_back()
@@ -192,27 +168,23 @@ static func _search(p_evaluator: FileEvaluator, p_from_dir: String = "res://", p
 			while file_name:
 				if first and not dir_name == p_from_dir:
 					first = false
-				# Ignore hidden content
+				# Ignore hidden content.
 				if not file_name.begins_with("."):
 					var a_path = dir.get_current_dir() + ("" if first else "/") + file_name
 					eval.set_file_path(a_path)
 
-					# If a directory, then add to list of directories to visit
+					# If a directory, then add to list of directories to visit.
 					if p_recursive and dir.current_is_dir():
 						dirs.push_back(dir.get_current_dir().plus_file(file_name))
 					# If a file, check if we already have a record for the same name.
-					# Only use files with extensions
+					# Only use files with extensions.
 					elif not data.has(a_path) and eval._is_match():
 						data[eval._get_key()] = eval._get_value()
 
-				# Move on to the next file in this directory
+				# Move on to the next file in this directory.
 				file_name = dir.get_next()
 
-			# We've exhausted all files in this directory. Close the iterator
+			# We've exhausted all files in this directory. Close the iterator.
 			dir.list_dir_end()
 
 	return data
-
-##### CONNECTIONS #####
-
-##### SETTERS AND GETTERS #####

--- a/addons/godot-next/global/file_system_link.gd
+++ b/addons/godot-next/global/file_system_link.gd
@@ -1,11 +1,10 @@
-# FileSystemLink
+class_name FileSystemLink
+extends Reference
 # author: willnationsdev
 # description: A utility for creating links (file/directory, symbolic/hard).
 # API details:
 #	- All methods' parameters are ordered in Unix fashion, {<target>,<linkpath>}
 #	- Methods are aliased so that the parameters are implied by the method name.
-extends Reference
-class_name FileSystemLink
 
 enum LinkTypes {
 	SOFT,
@@ -51,6 +50,7 @@ static func _make_link(p_target: String, p_linkpath: String = "", p_target_type 
 		TargetTypes.DIR, TargetTypes.WINDOWS_JUNCTION:
 			if not dir.dir_exists(target):
 				return ERR_FILE_NOT_FOUND
+	
 	match OS.get_name():
 		"Windows":
 			match p_link_type:
@@ -78,7 +78,7 @@ static func _make_link(p_target: String, p_linkpath: String = "", p_target_type 
 			#warning-ignore:return_value_discarded
 			OS.execute("mklink", params, true, output)
 			return OK
-		"X11", "OSX":
+		"X11", "OSX", "LinuxBSD":
 			match p_link_type:
 				LinkTypes.SOFT:
 					params.append("-s")

--- a/addons/godot-next/global/inspector_controls.gd
+++ b/addons/godot-next/global/inspector_controls.gd
@@ -1,18 +1,15 @@
-# InspectorControls
+class_name InspectorControls
+extends Reference
 # author: xdgamestudios
 # license: MIT
 # description:
-#	A collection of classes and factory methods for generating
-#	Controls oriented towards editing data. Useful for modifying
-#	the EditorInspector or generating your own in-game data-editing
-#	tools.
-extends Reference
-class_name InspectorControls
+#	A collection of classes and factory methods for generating Controls
+#	oriented towards editing data. Useful for modifying the
+#	EditorInspector or generating your own in-game data-editing tools.
 
 const ADD_ICON = preload("res://addons/godot-next/icons/icon_add.svg")
 
 class DropdownAppender extends HBoxContainer:
-	
 	func get_button() -> ToolButton:
 		return get_node("ToolButton") as ToolButton
 	
@@ -31,7 +28,7 @@ class DropdownAppender extends HBoxContainer:
 		return get_dropdown().get_selected_metadata()
 
 
-# Instantiates a Label. If align is not set the dafault ALIGN_LEFT will be used
+# Instantiates a Label. If align is not set the dafault ALIGN_LEFT will be used.
 static func new_label(p_label: String, p_align: int = Label.ALIGN_LEFT) -> Label:
 	var label = Label.new()
 	label.text = p_label
@@ -48,7 +45,8 @@ static func new_space(p_size: Vector2, p_horizontal_flag: int = Control.SIZE_EXP
 	return control
 
 
-# Instantiates a Button. If toggle mode is set, p_object/p_callback will connect to its "toggled" signal. Else, "pressed".
+# Instantiates a Button. If toggle mode is set, p_object/p_callback
+# will connect to its "toggled" signal. Else, "pressed".
 static func new_button(p_label: String, p_toggle_mode: bool = false, p_object: Object = null, p_callback: String = "") -> Button:
 	var button = Button.new()
 	button.text = p_label
@@ -64,7 +62,8 @@ static func new_button(p_label: String, p_toggle_mode: bool = false, p_object: O
 	return button
 
 
-# Instantiates a ToolButton. If toggle mode is set, p_object/p_callback will connect to its "toggled" signal. Else, "pressed".
+# Instantiates a ToolButton. If toggle mode is set, p_object/p_callback
+# will connect to its "toggled" signal. Else, "pressed".
 static func new_tool_button(p_icon: Texture, p_toggle_mode: bool = false, p_object: Object = null, p_callback: String = "") -> ToolButton:
 	var button = ToolButton.new()
 	button.icon = p_icon

--- a/addons/godot-next/global/physics_layers.gd
+++ b/addons/godot-next/global/physics_layers.gd
@@ -1,31 +1,28 @@
-# PhysicsLayers
+tool
+class_name PhysicsLayers
+extends Resource
 # author: xaguzman
 # license: MIT
-# description: A Utility class which allows easy access to your physics layers via their names in the project settings.
-tool
-extends Resource
+# description:
+#	A Utility class which allows easy access to your physics
+#	layers via their names in the project settings.
 
-class_name PhysicsLayers
-
-const Physics2D : int = 0
-const Physics3D : int = 1
-
-const _PHYSICS_LAYERS_BIT : Dictionary = {}
-const _PHYSICS_2D_PREFIX : String = "2d_physics"
-const _PHYSICS_3D_PREFIX : String = "3d_physics"
+const _PHYSICS_LAYERS_BIT: Dictionary = {}
+const _PHYSICS_2D_PREFIX = "2d_physics"
+const _PHYSICS_3D_PREFIX = "3d_physics"
 
 static func setup() -> void:
 	for prefix in [_PHYSICS_2D_PREFIX, _PHYSICS_3D_PREFIX]:
 		var path : String = "layer_names/".plus_file(prefix) 
 		for i in range(1, 21):
-			var layer_path : String = path.plus_file(str("layer_", i))	 
-			var layer_name : String = ProjectSettings.get(layer_path)
+			var layer_path: String = path.plus_file(str("layer_", i))
+			var layer_name: String = ProjectSettings.get(layer_path)
 
-			if(not layer_name): 
+			if not layer_name: 
 				layer_name = str("Layer ", i)
 
-			var layer_key : String = prefix.plus_file(layer_name)
-			_PHYSICS_LAYERS_BIT[layer_key] = i-1
+			var layer_key: String = prefix.plus_file(layer_name)
+			_PHYSICS_LAYERS_BIT[layer_key] = i - 1
 
 
 # Get the corresponding bit of the layer named <layer_name>
@@ -38,20 +35,19 @@ static func _get_physics_layer_index(layer_name: String) -> int:
 
 
 # Get the layer that corresponds to to the combination of all the passed layer names. 
-static func get_physics_layer(layer_names: Array, layer_type : int = Physics2D) -> int:
+static func get_physics_layer(layer_names: Array, is_layer_3d := false) -> int:
 	var res: int = 0
 	for i in range(layer_names.size()):
-		var layer_bit : int = get_physics_layer_index(layer_names[i], layer_type)
+		var layer_bit : int = get_physics_layer_index(layer_names[i], is_layer_3d)
 		res |= 1 << layer_bit
 	return res
 
 
-static func get_physics_layer_index(layer_name: String, layer_type : int = Physics2D) -> int:
-	var res : int
-	match layer_type:
-		Physics2D:
-			res = _get_physics_layer_index(_PHYSICS_2D_PREFIX.plus_file(layer_name))
-		Physics3D:
-			res = _get_physics_layer_index(_PHYSICS_3D_PREFIX.plus_file(layer_name))
+static func get_physics_layer_index(layer_name: String, is_layer_3d := false) -> int:
+	var res: int
+	if is_layer_3d:
+		res = _get_physics_layer_index(_PHYSICS_3D_PREFIX.plus_file(layer_name))
+	else:
+		res = _get_physics_layer_index(_PHYSICS_2D_PREFIX.plus_file(layer_name))
 	
 	return res

--- a/addons/godot-next/global/project_tools.gd
+++ b/addons/godot-next/global/project_tools.gd
@@ -1,10 +1,9 @@
-# ProjectTools
+tool
+class_name ProjectTools
+extends Reference
 # author: willnationsdev
 # license: MIT
 # description: A utility for any features useful in the context of a Godot Project.
-tool
-extends Reference
-class_name ProjectTools
 
 static func try_set_setting(p_name: String, p_default_value, p_pinfo: PropertyInfo) -> bool:
 	if ProjectSettings.has_setting(p_name):

--- a/addons/godot-next/global/singletons.gd
+++ b/addons/godot-next/global/singletons.gd
@@ -1,19 +1,16 @@
+tool
+class_name Singletons
+extends Reference
 # author: xdgamestudios
 # license: MIT
 # description: An API for accessing singletons
 # deps:
 #	- singleton_cache.tres
-tool
-extends Reference
-class_name Singletons
-
-##### CONSTANTS #####
 
 const SINGLETON_CACHE = preload("res://addons/godot-next/data/singleton_cache.tres")
 
-##### PUBLIC METHODS #####
-
-# Look up a singleton by its script. If it doesn't exist yet, make it. If it's a Resource with a persistent file path, load it in from memory.
+# Look up a singleton by its script. If it doesn't exist yet, make it.
+# If it's a Resource with a persistent file path, load it in from memory.
 static func fetch(p_script: Script) -> Object:
 	var cache: Dictionary = SINGLETON_CACHE.get_cache()
 	if not cache.has(p_script):
@@ -30,7 +27,7 @@ static func fetch(p_script: Script) -> Object:
 	return cache[p_script]
 
 
-# Returns a singleton by its class_name as a String
+# Returns a singleton by its class_name as a String.
 static func fetchs(p_name: String) -> Object:
 	var ct = ClassType.new(p_name)
 	if ct.res:
@@ -38,7 +35,7 @@ static func fetchs(p_name: String) -> Object:
 	return null
 
 
-# Returns an editor-only singleton by its class name
+# Returns an editor-only singleton by its class name.
 static func fetch_editor(p_class: GDScriptNativeClass) -> Object:
 	if not Engine.editor_hint:
 		push_warning("Cannot access '%s' (editor-only class) at runtime." % p_class.get_class())
@@ -76,13 +73,12 @@ static func save_all() -> void:
 		#warning-ignore:return_value_discarded
 		ResourceSaver.save(paths[a_script], cache[a_script])
 
-##### PRIVATE METHODS #####
 
 static func _get_persistent_path(p_script: Script):
 	return p_script.get("SELF_RESOURCE")
 
 
-# Register all editor-only singletons
+# Register all editor-only singletons.
 static func _register_editor_singletons(plugin: EditorPlugin):
 	var cache: Dictionary = SINGLETON_CACHE.get_cache()
 	

--- a/addons/godot-next/global/variant.gd
+++ b/addons/godot-next/global/variant.gd
@@ -1,13 +1,12 @@
-# Variant
+tool
+class_name Variant
+extends Reference
 # author: willnationsdev
 # license: MIT
 # description: A utility class for handling Variants.
-tool
-extends Reference
-class_name Variant
 
-# Returns a string form of all types, but allows Objects to override their string conversion
-static func to_string(p_value) -> String:
+# Returns a string form of all types, but allows Objects to override their string conversion.
+static func var_to_string(p_value) -> String:
 	if typeof(p_value) == TYPE_OBJECT and p_value.has_method("_to_string"):
 		return p_value._to_string() as String
 	return var2str(p_value)

--- a/addons/godot-next/gui/cycle.gd
+++ b/addons/godot-next/gui/cycle.gd
@@ -1,17 +1,7 @@
-# Cycle
-# author: willnationsdev
-# description: Cycles through child nodes without any visibility or container effects.
-
 class_name Cycle, "../icons/icon_cycle.svg"
 extends TabContainer
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
-
-##### PROPERTIES #####
-
-##### NOTIFICATIONS #####
+# author: willnationsdev
+# description: Cycles through child nodes without any visibility or container effects.
 
 func _init():
 	tabs_visible = false
@@ -23,9 +13,6 @@ func _ready():
 		if a_child is Control:
 			(a_child as Control).set_as_toplevel(true)
 
-##### VIRTUAL METHODS #####
-
-##### OVERRIDES #####
 
 func add_child(p_value: Node, p_legible_unique_name: bool = false):
 	.add_child(p_value, p_legible_unique_name)
@@ -37,9 +24,3 @@ func remove_child(p_value: Node):
 	.remove_child(p_value)
 	if p_value and p_value is Control:
 		(p_value as Control).set_as_toplevel(false)
-
-##### PUBLIC METHODS #####
-
-##### PRIVATE METHODS #####
-
-##### SETTERS AND GETTERS #####

--- a/addons/godot-next/gui/v_box_item_list.gd
+++ b/addons/godot-next/gui/v_box_item_list.gd
@@ -1,4 +1,5 @@
-# VBoxItemList
+class_name VBoxItemList, "../icons/icon_v_box_item_list.svg"
+extends VBoxContainer
 # author: willnationsdev
 # description: Creates a vertical list of items that can be added or removed. Items are a user-specified Script or Scene Control.
 # API details:
@@ -9,21 +10,12 @@
 #	- Items may define their own "_get_label" method which returns the string for their label text.
 #	- If either 'allow_reordering' or 'editable_labels' is true, labels will not be generated automatically via item_prefix + index.
 
-extends VBoxContainer
-class_name VBoxItemList, "../icons/icon_v_box_item_list.svg"
-
-##### SIGNALS #####
-
 signal item_inserted(p_index, p_control)
 signal item_removed(p_index, p_control)
-
-##### CONSTANTS #####
 
 const ICON_ADD: Texture = preload("../icons/icon_add.svg")
 const ICON_DELETE: Texture = preload("../icons/icon_import_fail.svg")
 const ICON_SLIDE: Texture = preload("../icons/icon_mirror_y.svg")
-
-##### PROPERTIES #####
 
 # The title text at the top of the node.
 export var title: String = "" setget set_title
@@ -53,8 +45,6 @@ var _dragged_item: HBoxContainer = null
 var _hovered_item: HBoxContainer = null
 var _insertions: int = 0
 var _removals: int = 0
-
-##### NOTIFICATIONS #####
 
 func _init(p_title: String = "", p_item_prefix: String = "", p_type: Resource = null):
 	if p_type:
@@ -94,21 +84,18 @@ func _process(_delta: float):
 			(a_child.get_node("ItemEdit") as LineEdit).hide()
 			(a_child.get_node("ItemLabel") as Label).show()
 
-##### OVERRIDES #####
-
-##### VIRTUAL METHODS #####
 
 #warning-ignore:unused_argument
 #warning-ignore:unused_argument
 func _item_inserted(p_index: int, p_control: Control):
 	pass
 
+
 #warning-ignore:unused_argument
 #warning-ignore:unused_argument
 func _item_removed(p_index: int, p_control: Control):
 	pass
 
-##### PUBLIC METHODS #####
 
 func insert_item(p_index: int) -> Control:
 	var node: Control = _get_node_from_type()
@@ -184,11 +171,10 @@ func remove_item(p_idx: int):
 		_reset_prefixes()
 	_item_removed(p_idx, node)
 	emit_signal("item_removed", p_idx, node)
-	if (is_instance_valid(node)):
+	if is_instance_valid(node):
 		node.free()
 	_removals += 1
 
-##### CONNECTIONS #####
 
 func _on_remove_item(p_del_btn: ToolButton):
 	remove_item(p_del_btn.get_parent().get_index())
@@ -199,6 +185,7 @@ func _on_slide_gui_input(p_event: InputEvent, p_rect: TextureRect):
 		var mb := p_event as InputEventMouseButton
 		if not mb.is_echo() and mb.button_index == BUTTON_LEFT and mb.pressed:
 			_dragged_item = p_rect.get_parent() as HBoxContainer
+
 
 func _on_hbox_gui_input(p_event: InputEvent, p_hbox: HBoxContainer):
 	if p_event is InputEventMouseButton:
@@ -248,7 +235,6 @@ func _on_edit_text_entered(p_text: String, p_edit: LineEdit, p_label: Label):
 	p_label.show()
 	p_edit.hide()
 
-##### PRIVATE METHODS #####
 
 func _get_node_from_type() -> Control:
 	if item_script:
@@ -314,7 +300,6 @@ func _validate_item_type(p_res: Resource) -> bool:
 	
 	return true
 
-##### SETTERS AND GETTERS #####
 
 func set_title(p_value: String):
 	title = p_value

--- a/addons/godot-next/inspector_plugins/delegation_inspector_plugin.gd
+++ b/addons/godot-next/inspector_plugins/delegation_inspector_plugin.gd
@@ -1,4 +1,5 @@
-# DelegationInspectorPlugin
+tool
+extends EditorInspectorPlugin
 # author: willnationsdev and xdgamestudios
 # license: MIT
 # description:
@@ -6,8 +7,6 @@
 #	object that appears in an EditorInspector anywhere. Enables
 #	objects to define their own EditorInspector GUI logic without
 #	the need for additional plugins.
-tool
-extends EditorInspectorPlugin
 
 var obj_stack: Array
 

--- a/addons/godot-next/nodes/callback_delegator.gd
+++ b/addons/godot-next/nodes/callback_delegator.gd
@@ -1,4 +1,6 @@
-# CallbackDelegator
+tool
+class_name CallbackDelegator
+extends Node
 # author: xdgamestudios
 # license: MIT
 # description:
@@ -27,17 +29,6 @@
 #			1. _awake() called during _enter_tree() after CallbackDelegator initializes owner (for Unity familiarity).
 #			2. _enter_tree() called immediately after (so they are virtually aliases for each other)
 #			3. _ready() called during _ready().
-tool
-extends Node
-class_name CallbackDelegator
-
-##### CLASSES #####
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
-
-##### PROPERTIES #####
 
 # The collection of Resources. Only one Resource of each type is allowed.
 var _elements: ResourceSet = ResourceSet.new()
@@ -56,12 +47,6 @@ var _callbacks: Dictionary = {
 
 # Assists with inheritance checks and name identification of script classes.
 var _class_type: ClassType = ClassType.new()
-
-##### NOTIFICATIONS #####
-
-func _get_property_list() -> Array:
-	return [ PropertyInfo.new_resource("_elements").to_dict() ]
-
 
 func _ready() -> void:
 	_handle_notification("_ready")
@@ -101,18 +86,9 @@ func _unhandled_input(event: InputEvent) -> void:
 func _unhandled_key_input(event: InputEventKey) -> void:
 	_handle_notification("_unhandled_key_input", event)
 
-##### OVERRIDES #####
 
-func _parse_property(p_inspector: EditorInspectorPlugin, p_pinfo: PropertyInfo) -> void:
-	match p_pinfo.name:
-		"_elements":
-			p_inspector.add_custom_control(InspectorControls.new_button("Initialize Default Behavior", false, self, "_set_base_type_behavior"))
-
-##### VIRTUALS #####
-
-##### PUBLIC METHODS #####
-
-# Add an element to the CallbackDelegator. Does nothing if no base_type is assigned. See `set_base_type(...)`.
+# Add an element to the CallbackDelegator. Does nothing if no
+# base_type is assigned. See `set_base_type(...)`.
 func add_element(p_type: Script) -> Resource:
 	var elements = _elements.get_data()
 	
@@ -144,7 +120,8 @@ func has_element(p_type: Script) -> bool:
 	return elements.has(_class_type.get_script_class())
 
 
-# Returns true if successfully able to remove the element from the internal collection. Else, returns false.
+# Returns true if successfully able to remove the element
+# from the internal collection. Else, returns false.
 func remove_element(p_type: Script) -> bool:
 	var elements = _elements.get_data()
 	var element = get_element(p_type)
@@ -155,18 +132,27 @@ func remove_element(p_type: Script) -> bool:
 	return false
 
 
-# The order of returned Scripts is not deterministic
+# The order of returned Scripts is not deterministic.
 func get_element_types() -> Array:
 	return _elements.get_data().keys()
 
 
-# The order of returned Resources is not deterministic
+# The order of returned Resources is not deterministic.
 func get_elements() -> Array:
 	return _elements.get_data().values()
 
-##### PRIVATE METHODS #####
 
-# Helper method to facilitate delegation of the callback
+func _parse_property(p_inspector: EditorInspectorPlugin, p_pinfo: PropertyInfo) -> void:
+	match p_pinfo.name:
+		"_elements":
+			p_inspector.add_custom_control(InspectorControls.new_button("Initialize Default Behavior", false, self, "_set_base_type_behavior"))
+
+
+func _get_property_list() -> Array:
+	return [ PropertyInfo.new_resource("_elements").to_dict() ]
+
+
+# Helper method to facilitate delegation of the callback.
 func _handle_notification(p_name: String, p_param = null) -> void:
 	if Engine.editor_hint:
 		return
@@ -177,9 +163,10 @@ func _handle_notification(p_name: String, p_param = null) -> void:
 		for an_element in _callbacks[p_name]:
 			an_element.call(p_name)
 
+
 # Setup the owner and initialization of the element. Ensure it updates its callbacks if the script is modified.
 func _initialize_element(p_element: Resource) -> void:
-	__awake(p_element)
+	_awake(p_element)
 	#warning-ignore:return_value_discarded
 	p_element.connect("script_changed", self, "_refresh_callbacks", [p_element])
 	_add_to_callbacks(p_element)
@@ -216,12 +203,11 @@ func _check_for_empty_callbacks() -> void:
 
 
 # Sets up the owner instance on the Behavior.
-func __awake(p_element: Resource) -> void:
+func _awake(p_element: Resource) -> void:
 	p_element.owner = self
 	if p_element.has_method("_awake"):
 		p_element._awake()
 
-##### CONNECTIONS #####
 
 # Reset callback registrations in the event that the script is modified.
 func _on_element_script_change(p_element: Resource) -> void:
@@ -232,5 +218,3 @@ func _on_element_script_change(p_element: Resource) -> void:
 func _set_base_type_behavior() -> void:
 	_class_type.name = "Behavior"
 	_elements.set_base_type(_class_type.res)
-
-##### SETTERS AND GETTERS #####

--- a/addons/godot-next/nodes/message_dispatcher_wrapper.gd
+++ b/addons/godot-next/nodes/message_dispatcher_wrapper.gd
@@ -1,4 +1,5 @@
-# MessageDispatcherWrapper
+class_name MessageDispatcherWrapper
+extends Node
 # author: MunWolf (Rikhardur Bjarni Einarsson)
 # license: MIT
 # copyright: Copyright (c) 2019 Rikhardur Bjarni Einarsson
@@ -7,31 +8,23 @@
 #	people can also use this as a template to implement it on
 #	their own if they want to extend something else.
 
-extends Node
-
-class_name MessageDispatcherWrapper
-
-##### PROPERTIES #####
-
 var _message_dispatcher = MessageDispatcher.new()
 
-##### PUBLIC METHODS #####
-
-# See same function on MessageDispatcher
+# See same function on MessageDispatcher.
 func connect_message(message_type: String, obj: Object, function: String) -> void:
 	_message_dispatcher.connect_message(message_type, obj, function)
 
 
-# See same function on MessageDispatcher
+# See same function on MessageDispatcher.
 func disconnect_message(message_type: String, obj: Object, function: String) -> void:
 	_message_dispatcher.disconnect_message(message_type, obj, function)
 
 
-# See same function on MessageDispatcher
+# See same function on MessageDispatcher.
 func disconnect_all_message() -> void:
 	_message_dispatcher.disconnect_all_message()
 
 
-# See same function on MessageDispatcher
+# See same function on MessageDispatcher.
 func emit_message(message_type: String, message_data: Dictionary) -> bool:
 	return _message_dispatcher.emit_message(message_type, message_data)

--- a/addons/godot-next/references/array_2d.gd
+++ b/addons/godot-next/references/array_2d.gd
@@ -1,27 +1,13 @@
-# Array2D
+class_name Array2D
+extends Reference
 # author: willnationsdev
 # description: A 2D Array class
-extends Reference
-class_name Array2D
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
-
-##### PROPERTIES #####
 
 var data: Array = []
-
-##### NOTIFICATIONS #####
 
 func _init(p_array: Array = []):
 	data = p_array
 
-##### OVERRIDES #####
-
-##### VIRTUAL METHODS #####
-
-##### PUBLIC METHODS #####
 
 func has_cell(p_row: int, p_col: int) -> bool:
 	return len(data) > p_row and len(data[p_row]) > p_col
@@ -303,10 +289,6 @@ func transpose() -> Array2D:
 		array.append_row(get_col(i))
 	return array
 
-
-##### CONNECTIONS #####
-
-##### PRIVATE METHODS #####
 
 func _sort_axis(p_idx: int, p_is_row: bool):
 	if p_is_row:

--- a/addons/godot-next/references/bit_flag.gd
+++ b/addons/godot-next/references/bit_flag.gd
@@ -1,4 +1,6 @@
-# BitFlag
+tool
+class_name BitFlag
+extends Reference
 # author: xdgamestudios
 # license: MIT
 # description: A class that allows abstracts away the complexity of handling bit flag enum types.
@@ -24,16 +26,9 @@
 #		bf.get_keys() # Returns an array of all flag keys.
 #	- Convert to PropertyInfo dict
 #		bf.to_pinfo_dict("property_name") # Returns a dictionary with export structure.
-tool
-extends Reference
-class_name BitFlag
-
-##### PROPERTIES #####
 
 var _enum: Dictionary = {}
 var _flags: int = 0 setget set_flags, get_flags
-
-##### NOTIFICATIONS #####
 
 func _init(p_enum: Dictionary, p_to_flag: bool = false):
 	if p_to_flag:
@@ -69,7 +64,6 @@ func _get_value_flags(p_value) -> int:
 	assert(false)
 	return -1
 
-##### PUBLIC METHODS #####
 
 func put(p_value) -> int:
 	if p_value == null:
@@ -115,9 +109,6 @@ func to_pinfo_dict(p_name: String) -> Dictionary:
 	var hint_string = PoolStringArray(get_keys()).join(",")
 	return PropertyInfo.new(p_name, TYPE_INT, PROPERTY_HINT_FLAGS, hint_string).to_dict()
 
-##### PRIVATE METHODS #####
-
-##### SETTERS AND GETTERS #####
 
 func get_flags() -> int:
 	return _flags

--- a/addons/godot-next/references/bitset.gd
+++ b/addons/godot-next/references/bitset.gd
@@ -1,4 +1,5 @@
-# Bitset
+class_name Bitset
+extends Reference
 # author: milesturin
 # license: MIT
 # description: A class that allows for easily manipulated bitmasks of any size
@@ -6,24 +7,14 @@
 #	By setting enforce_soft_size to false, the Bitset will allow the user to access
 #	bits that have been reserved by the script, but are outside of the requested size.
 
-extends Reference
-class_name Bitset
-
-### CONSTANTS ###
-
 const MASK_SIZE := 32
-
-### PROPERTIES ###
 
 var bitmasks: PoolIntArray = []
 var bits: int
 
-### NOTIFICATIONS ###
-
 func _init(size: int, default_state: bool = false, enforce_soft_size: bool = true) -> void:
 	resize(size, default_state, enforce_soft_size)
 
-### PUBLIC METHODS ###
 
 func resize(size: int, default_state: bool = false, enforce_soft_size: bool = true) -> void:
 	assert(size >= 0)

--- a/addons/godot-next/references/class_type.gd
+++ b/addons/godot-next/references/class_type.gd
@@ -1,4 +1,6 @@
-# ClassType
+tool
+class_name ClassType
+extends Reference
 # author: willnationsdev
 # license: MIT
 # description:
@@ -66,24 +68,13 @@
 #		
 #		var list: PoolStringArray = ct.get_deep_inheritors_list() # get all types that inherit "MyNode" (engine + script and scene resources, namified paths for anonymous ones)
 #		var ct = ClassType.from_type_dict(type_map[list[0]]) # factory method handles init logic
-tool
-extends Reference
-class_name ClassType
-
-##### CLASSES #####
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
 
 enum Source {
 	NONE,
 	ENGINE,
 	SCRIPT,
-	ANONYMOUS
+	ANONYMOUS,
 }
-
-##### PROPERTIES #####
 
 export var name: String = "" setget set_name, get_name
 export(String, FILE) var path: String = "" setget set_path, get_path
@@ -98,8 +89,6 @@ var _deep_path_map: Dictionary = {}
 
 var _script_map_dirty: bool = true
 var _is_filesystem_connected: bool = false
-
-##### NOTIFICATIONS #####
 
 func _init(p_input = null, p_generate_deep_map: bool = true, p_duplicate_maps: bool = true) -> void:
 	if p_generate_deep_map:
@@ -130,11 +119,6 @@ func _init(p_input = null, p_generate_deep_map: bool = true, p_duplicate_maps: b
 				_connect_script_updates()
 	return
 
-##### OVERRIDES #####
-
-##### VIRTUALS #####
-
-##### PUBLIC METHODS #####
 
 # Returns the name of the class or resource.
 # Anonymous resources' paths are namified.
@@ -149,16 +133,15 @@ func to_string():
 		return named_path
 	return ""
 
-# Get Dictionary<name, data> map for script classes
+
+# Get Dictionary<name, data> map for script classes.
 # 'data' is a Dictionary with the following format:
-"""
-{
-	'base': <engine class name>
-	'name': <name given to script>
-	'language': <scripting language>
-	'path': <path to script>
-}
-"""
+#{
+#	'base': <engine class name>
+#	'name': <name given to script>
+#	'language': <scripting language>
+#	'path': <path to script>
+#}
 
 # Caches script maps for faster access.
 # Does not cache in the editor context.
@@ -167,7 +150,7 @@ func get_script_classes() -> Dictionary:
 	return _script_map
 
 
-# Get Dictionary<path, name> map for script classes
+# Get Dictionary<path, name> map for script classes.
 # Caches script maps for faster access.
 # Does not cache in the editor context.
 func get_path_map() -> Dictionary:
@@ -175,41 +158,28 @@ func get_path_map() -> Dictionary:
 	return _path_map
 
 
-# Same as get_script_map, but it includes all resources
+# Same as get_script_map, but it includes all resources.
 func get_deep_type_map() -> Dictionary:
 	_fetch_deep_type_map()
 	return _deep_type_map
 
 
-# Same as get_path_map, but it includes all resources
+# Same as get_path_map, but it includes all resources.
 func get_deep_path_map() -> Dictionary:
 	_fetch_deep_type_map()
 	return _deep_path_map
 
 
-# Forces a refresh of the script maps
+# Forces a refresh of the script maps.
 func refresh_script_classes() -> void:
 	_script_map = _get_script_map()
 	_build_path_map()
 
 
-# Same as refresh_script_map, but it includes all resources
+# Same as refresh_script_map, but it includes all resources.
 func refresh_deep_type_map() -> void:
 	_deep_type_map = _get_deep_type_map()
 	_build_deep_path_map()
-
-
-# Get a type map. Minimum: _script_map. Maximum: _deep_type_map.
-func _get_map() -> Dictionary:
-	var map := {}
-	# don't initialize unless player has already done so
-	if not _deep_type_map.empty():
-		map = _deep_type_map
-	# if we aren't using the deep map, then get the standard one
-	if map.empty():
-		_fetch_script_map()
-		map = _script_map
-	return map
 
 
 # Is this ClassType the same as or does it inherit another class name/resource?
@@ -237,7 +207,7 @@ func is_type(p_other) -> bool:
 	return static_is_type(res, p_other, _get_map())
 
 
-# Instantiate whatever type the ClassType refers to
+# Instantiate whatever type the ClassType refers to.
 func instance() -> Object:
 	if _source == Source.ENGINE:
 		return ClassDB.instance(name)
@@ -249,7 +219,7 @@ func instance() -> Object:
 	return null
 
 
-# Get the name of the next inherited engine class
+# Get the name of the next inherited engine class.
 func get_engine_class() -> String:
 	if Source.ENGINE == _source:
 		return name
@@ -262,7 +232,7 @@ func get_engine_class() -> String:
 	return ""
 
 
-# Get the name of the next inherited script
+# Get the name of the next inherited script.
 func get_script_class() -> String:
 	match _source:
 		Source.ENGINE:
@@ -312,17 +282,17 @@ func is_non_class_res() -> bool:
 	return path_exists() and not class_exists()
 
 
-# Cast to Script
+# Cast to Script.
 func as_script() -> Script:
 	return res as Script
 
 
-# Cast to PackedScene
+# Cast to PackedScene.
 func as_scene() -> PackedScene:
 	return res as PackedScene
 
 
-# get inherited engine class as ClassType
+# Get inherited engine class as ClassType.
 func get_engine_parent() -> Reference:
 	var ret := _new()
 	if _source == Source.SCRIPT:
@@ -332,7 +302,7 @@ func get_engine_parent() -> Reference:
 	return ret
 
 
-# get inherited script resource as ClassType
+# Get inherited script resource as ClassType.
 func get_script_parent() -> Reference:
 	var ret := _new()
 	if _source == Source.ENGINE:
@@ -352,7 +322,7 @@ func get_script_parent() -> Reference:
 	return ret
 
 
-# get inherited scene resource as ClassType
+# Get inherited scene resource as ClassType.
 func get_scene_parent() -> Reference:
 	var ret := _new()
 	match _source:
@@ -364,7 +334,7 @@ func get_scene_parent() -> Reference:
 	return ret
 
 
-# get inherited resource or engine class as ClassType
+# Get inherited resource or engine class as ClassType.
 func get_type_parent() -> Reference:
 	var ret = get_scene_parent()
 	if ret.is_valid():
@@ -377,22 +347,21 @@ func get_type_parent() -> Reference:
 
 # Convert the current ClassType into its base ClassType. Returns true if valid.
 # Can use an inheritance loop like so:
-"""
 # Where my_node.tscn is a scene with a MyNode script attached to a Node root
 # and MyNode is a script class extending Node
 
-var ct = ClassType.new('res://my_node.tscn')
-print(ct.to_string())
-while ct.become_parent():
-	print(ct.to_string())
+#	var ct = ClassType.new('res://my_node.tscn')
+#	print(ct.to_string())
+#	while ct.become_parent():
+#		print(ct.to_string())
 
 # prints:
 
-MyNodeScn
-MyNode
-Node
-Object
-"""
+# MyNodeScn
+# MyNode
+# Node
+# Object
+
 func become_parent() -> bool:
 	if not res:
 		if not name:
@@ -435,6 +404,11 @@ func can_instance() -> bool:
 	return false
 
 
+func is_object_instance_of(p_object) -> bool:
+	var ct = from_object(p_object)
+	return is_type(ct)
+
+
 # Generate a list of named classes that extend the represented class or
 # resource. SLOW
 func get_inheritors_list() -> PoolStringArray:
@@ -457,18 +431,18 @@ func get_deep_inheritors_list() -> PoolStringArray:
 	return ret
 
 
-# Generate a list of engine class names
+# Generate a list of engine class names.
 func get_engine_class_list() -> PoolStringArray:
 	return ClassDB.get_class_list()
 
 
-# Generate a list of script class names
+# Generate a list of script class names.
 func get_script_class_list() -> PoolStringArray:
 	_fetch_script_map()
 	return PoolStringArray(_script_map.keys())
 
 
-# Generate a list of all named classes
+# Generate a list of all named classes.
 func get_class_list() -> PoolStringArray:
 	var class_list := PoolStringArray()
 	class_list.append_array(get_engine_class_list())
@@ -476,7 +450,7 @@ func get_class_list() -> PoolStringArray:
 	return class_list
 
 
-# Generate a list of class names
+# Generate a list of class names.
 func get_deep_class_list() -> PoolStringArray:
 	_fetch_deep_type_map()
 	var class_list := PoolStringArray(_deep_type_map.keys())
@@ -484,17 +458,30 @@ func get_deep_class_list() -> PoolStringArray:
 	return class_list
 
 
-# Generate a list of all engine and resource names
+# Get a type map. Minimum: _script_map. Maximum: _deep_type_map.
+func _get_map() -> Dictionary:
+	var map := {}
+	# Don't initialize unless player has already done so.
+	if not _deep_type_map.empty():
+		map = _deep_type_map
+	# If we aren't using the deep map, then get the standard one.
+	if map.empty():
+		_fetch_script_map()
+		map = _script_map
+	return map
+
+
+# Generate a list of all engine and resource names.
 static func static_get_engine_class_list() -> PoolStringArray:
 	return ClassDB.get_class_list()
 
 
-# Generate a list of script class names
+# Generate a list of script class names.
 static func static_get_script_class_list() -> PoolStringArray:
 	return PoolStringArray(_get_script_map().keys())
 
 
-# Generate a list of all named classes
+# Generate a list of all named classes.
 static func static_get_class_list() -> PoolStringArray:
 	var class_list := PoolStringArray()
 	class_list.append_array(static_get_engine_class_list())
@@ -502,7 +489,7 @@ static func static_get_class_list() -> PoolStringArray:
 	return class_list
 
 
-# Generate a list of all engine and resource names
+# Generate a list of all engine and resource names.
 static func static_get_deep_class_list() -> PoolStringArray:
 	var _deep_type_map = _get_deep_type_map()
 	var class_list := PoolStringArray(_deep_type_map.keys())
@@ -510,12 +497,7 @@ static func static_get_deep_class_list() -> PoolStringArray:
 	return class_list
 
 
-func is_object_instance_of(p_object) -> bool:
-	var ct = from_object(p_object)
-	return is_type(ct)
-
-
-# Tests whether an object constitutes a class name or resource
+# Tests whether an object constitutes a class name or resource.
 static func static_is_object_instance_of(p_object, p_type, p_map: Dictionary = {}) -> bool:
 	if not p_object or typeof(p_object) != TYPE_OBJECT:
 		return false
@@ -532,11 +514,11 @@ static func static_is_object_instance_of(p_object, p_type, p_map: Dictionary = {
 
 
 # Tests whether a class name or resource constitutes another
-# String names and Resource instances are interchangeable
+# String names and Resource instances are interchangeable.
 # Ex. static_is_type(MyNode, "Node") == static_is_type("MyNode", "Node"), etc.
 # PackedScenes are also supported.
 # Note that scenes are capable of inheriting from divergent
-# script and scene inheritance hierarchies simultaneously
+# script and scene inheritance hierarchies simultaneously.
 static func static_is_type(p_type, p_other, p_map: Dictionary = {}) -> bool:
 	if not p_type:
 		return false
@@ -629,7 +611,7 @@ static func from_object(p_object: Object) -> Reference:
 	return ret
 
 
-# Utility function to create from `get_deep_type_map()` values
+# Utility function to create from `get_deep_type_map()` values.
 static func from_type_dict(p_data: Dictionary) -> Reference:
 	var ret := _new()
 	match p_data.type:
@@ -647,11 +629,8 @@ static func namify_path(p_path: String) -> String:
 		p = p.get_basename()
 	return p.capitalize().replace(" ", "")
 
-##### CONNECTIONS #####
 
-##### PRIVATE METHODS #####
-
-# reset properties based on a given name
+# Reset properties based on a given name.
 func _init_from_name(p_name: String) -> void:
 	name = p_name
 	if ClassDB.class_exists(p_name):
@@ -679,7 +658,7 @@ func _init_from_name(p_name: String) -> void:
 	_connect_script_updates()
 
 
-# reset properties based on a given path
+# Reset properties based on a given path.
 func _init_from_path(p_path: String) -> void:
 	path = p_path
 	res = load(path) if ResourceLoader.exists(path) else null
@@ -699,17 +678,17 @@ func _init_from_path(p_path: String) -> void:
 	_connect_script_updates()
 
 
-# reset properties based on a given object instance
-# if null: don't initialize.
-# if a scene's root node, become the scene.
-# if an object with a script, become that script.
-# otherwise, if a Script or PackedScene, become that.
-# otherwise, become whatever the given class is
-# Note:
-# 1. Due to this logic, one cannot set a ClassType to be "Script" or
-#	"PackedScene" with this method.
-# 2. Due to this logic, one cannot become a specialized type of PackedScene
-#	resource that has its own script.
+# Reset properties based on a given object instance.
+#	If null: don't initialize.
+#	Else, if a scene's root node, become the scene.
+#	Else, if an object with a script, become that script.
+#	Else, if a Script or PackedScene, become that.
+#	Else, become whatever the given class is.
+# Notes:
+#	1. Due to this logic, one cannot set a ClassType to be "Script" or
+#	   "PackedScene" with this method.
+#	2. Due to this logic, one cannot become a specialized type of PackedScene
+#	   resource that has its own script.
 func _init_from_object(p_object: Object) -> void:
 	var initialized: bool = false
 	if not p_object:
@@ -970,7 +949,6 @@ static func _scene_get_root_scene(p_scene: PackedScene) -> PackedScene:
 	var state := p_scene.get_state()
 	return state.get_node_instance(0)
 
-##### SETTERS AND GETTERS #####
 
 # Re-initialize based on assigned name.
 func set_name(p_value: String) -> void:

--- a/addons/godot-next/references/csv_file.gd
+++ b/addons/godot-next/references/csv_file.gd
@@ -1,4 +1,6 @@
-# CSVFile
+tool
+class_name CSVFile
+extends Reference
 # author: willnationsdev
 # description: Provides utilities for loading, saving, and editing CSV files.
 # dependencies: Array2D
@@ -11,21 +13,12 @@
 #		  Else _map will be empty. Defaults to false.
 #		- The CSVFile object dynamically generates properties that match the keys of the _map Dictionary.
 #	- A .tsv file can be made simply by changing the '_sep' property to "\t".
-tool
-extends Reference
-class_name CSVFile
-
-##### SIGNALS #####
 
 signal file_loaded(p_filepath)
 signal file_saved(p_filepath)
 
-##### CONSTANTS #####
-
 const DEFAULT_SEP = ","
 const DEFAULT_QUOTE = "\""
-
-##### PROPERTIES #####
 
 var _filepath := ""
 
@@ -36,8 +29,6 @@ var _map := {}
 var _sep := DEFAULT_SEP
 var _quote := DEFAULT_QUOTE
 var _uses_map := true
-
-##### NOTIFICATIONS #####
 
 func _init(p_sep: String = DEFAULT_SEP, p_quote: String = DEFAULT_QUOTE, p_uses_map: bool = true):
 	_sep = p_sep
@@ -64,18 +55,14 @@ func _get_property_list():
 		})
 	return ret
 
-##### VIRTUAL METHODS #####
 
 func _get_key(p_row: Array) -> String:
 	if not p_row:
 		return ""
 	return p_row[0]
 
-##### OVERRIDES #####
 
-##### PUBLIC METHODS #####
-
-func load(p_filepath: String) -> int:
+func load_file(p_filepath: String) -> int:
 	var f = File.new()
 	var err = f.open(p_filepath, File.READ)
 	if err != OK:
@@ -107,7 +94,7 @@ func load(p_filepath: String) -> int:
 	return OK
 
 
-func save(p_filepath: String) -> int:
+func save_file(p_filepath: String) -> int:
 	var f := File.new()
 	var err := f.open(p_filepath, File.WRITE)
 	if err != OK:
@@ -159,7 +146,6 @@ func map_set_value(p_key: String, p_header: String, p_value):
 		return null
 	_map[p_key][_headers[p_header]] = p_value
 
-##### PRIVATE METHODS #####
 
 func _parse_line(p_line: String) -> Array:
 	if not p_line:
@@ -208,5 +194,3 @@ func _parse_line(p_line: String) -> Array:
 				val += s
 	ret.append(val)
 	return ret
-
-##### SETTERS AND GETTERS #####

--- a/addons/godot-next/references/inflector.gd
+++ b/addons/godot-next/references/inflector.gd
@@ -1,3 +1,6 @@
+tool
+class_name Inflector
+extends Reference
 # author: xdgamestudios (adapted from C# .NET Humanizer, licensed under MIT)
 # license: MIT
 # description: Provides inflection tools to pluralize and singularize strings.
@@ -29,20 +32,10 @@
 #		inflector.singularize(word, p_force = false) # returns the singular of the word
 #		Note:
 #		- If the first parameter's state is unknown, use 'p_force = true' to force an unknown term into the desired state.
-tool
-extends Reference
-class_name Inflector
-
-##### CLASSES #####
 
 class Rule extends Reference:
-	
-	##### PROPERTIES #####
-	
 	var _regex: RegEx
 	var _replacement: String
-	
-	##### NOTIFICATIONS #####
 	
 	func _init(p_rule: String, p_replacement: String) -> void:
 		_regex = RegEx.new()
@@ -50,7 +43,6 @@ class Rule extends Reference:
 		_regex.compile(p_rule)
 		_replacement = p_replacement
 	
-	##### PUBLIC METHODS #####
 	
 	func apply(p_word: String):
 		if not _regex.search(p_word):
@@ -59,14 +51,10 @@ class Rule extends Reference:
 
 
 class Vocabulary extends Reference:
-	
-	##### PROPERTIES #####
-	
 	var _plurals: Array = [] setget, get_plurals
 	var _singulars: Array = [] setget, get_singulars
 	var _uncountables: Array = [] setget, get_uncountables
 	
-	##### PUBLIC METHODS #####
 	
 	func get_plurals() -> Array:
 		return _plurals
@@ -110,10 +98,9 @@ class Vocabulary extends Reference:
 	
 	
 	static func build_default_vocabulary() -> Vocabulary:
-		
 		var vocabulary = Vocabulary.new()
 		
-		# plurals rules
+		# Plural rules.
 		vocabulary._plurals = [
 			Rule.new("$", "s"),
 			Rule.new("s$", "s"),
@@ -138,7 +125,7 @@ class Vocabulary extends Reference:
 			Rule.new("(criteri|phenomen)on$", "$1a")
 		]
 		
-		# singular rules
+		# Singular rules.
 		vocabulary._singulars = [
 			Rule.new("s$", ""),
 			Rule.new("(n)ews$", "$1ews"),
@@ -168,7 +155,7 @@ class Vocabulary extends Reference:
 			Rule.new("([b|r|c]ook|room|smooth)ies$", "$1ie")
 		]
 		
-		# irregular rules
+		# Irregular rules.
 		vocabulary.add_irregular("person", "people")
 		vocabulary.add_irregular("man", "men")
 		vocabulary.add_irregular("human", "humans")
@@ -191,7 +178,7 @@ class Vocabulary extends Reference:
 		vocabulary.add_irregular("bus", "buses", true)
 		vocabulary.add_irregular("staff", "staff", true)
 		
-		#  uncountables
+		# Uncountables.
 		vocabulary._uncountables = [
 			"equipment",
 			"information",
@@ -236,11 +223,8 @@ class Vocabulary extends Reference:
 		
 		return vocabulary
 
-##### PROPERTIES #####
 
 var _vocabulary: Vocabulary setget, get_vocabulary
-
-##### NOTIFICATIONS #####
 
 func _init(p_vocabulary = null) -> void:
 	if not p_vocabulary:
@@ -248,7 +232,6 @@ func _init(p_vocabulary = null) -> void:
 	else:
 		_vocabulary = p_vocabulary
 
-##### PUBLIC METHODS #####
 
 func get_vocabulary() -> Vocabulary:
 	return _vocabulary

--- a/addons/godot-next/references/message_dispatcher.gd
+++ b/addons/godot-next/references/message_dispatcher.gd
@@ -1,4 +1,5 @@
-# MessageDispatcher
+class_name MessageDispatcher
+extends Reference
 # author: MunWolf (Rikhardur Bjarni Einarsson)
 # license: MIT
 # copyright: Copyright (c) 2019 Rikhardur Bjarni Einarsson
@@ -6,14 +7,7 @@
 #	A message handler for non predefined signals, if you want to use this
 #	by extending it on a Node, please use MessageDispatcherWrapper.
 
-extends Reference
-class_name MessageDispatcher
-
-##### PROPERTIES #####
-
 var _message_handlers := {}
-
-##### PUBLIC METHODS #####
 
 # Connect a handler, obj has to have a function that corresponds to the parameter.
 #	message_type: type of the message, we call obj.function(message) based on this.

--- a/addons/godot-next/references/property_info.gd
+++ b/addons/godot-next/references/property_info.gd
@@ -1,31 +1,20 @@
-# PropertyInfo
+tool
+class_name PropertyInfo
+extends Reference
 # author: xdgamestudios
 # license: MIT
 # description:
 #	A wrapper and utility class for generating PropertyInfo
 #	Dictionaries, of which Object._get_property_list()
 #	returns an Array.
-tool
-extends Reference
-class_name PropertyInfo
-
-##### CLASSES #####
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
 
 const SELF_PATH: String = "res://addons/godot-next/references/property_info.gd"
-
-##### PROPERTIES #####
 
 var name: String
 var type: int
 var hint: int
 var hint_string: String
 var usage: int
-
-##### NOTIFICATIONS #####
 
 func _init(p_name: String = "", p_type: int = TYPE_NIL, p_hint: int = PROPERTY_HINT_NONE, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> void:
 	name = p_name
@@ -34,7 +23,6 @@ func _init(p_name: String = "", p_type: int = TYPE_NIL, p_hint: int = PROPERTY_H
 	hint_string = p_hint_string
 	usage = p_usage
 
-##### PUBLIC METHODS #####
 
 func to_dict() -> Dictionary:
 	return {

--- a/addons/godot-next/references/tween_sequence.gd
+++ b/addons/godot-next/references/tween_sequence.gd
@@ -1,12 +1,10 @@
-# TweenSequence
+class_name TweenSequence
+extends Reference
 # author: KoBeWi
 # license: MIT
 # description:
 #	A helper class for easier management and chaining of Tweens.
 #	dynamically from code.
-#	Consult comments above methods to see what they do.
-#	They are marked with ## for easier navigation.
-#	Anything starting with __ should not be accessed.
 #	
 #	Example usage:
 #		var seq := TweenSequence.new(get_tree())
@@ -16,392 +14,381 @@
 #	changing the Sprite to red color in one second
 #	and then making it transparent after a delay.
 
-class_name TweenSequence
-extends Reference
+# Abstract class for all Tweeners.
+class Tweener extends Reference:
+	func _start(tween: Tween) -> void:
+		pass
 
-var __tree: SceneTree
-var __tween: Tween
-var __tweeners: Array
 
-var __current_step := 0
-var __loops := 0
-var __autostart := true
-var __started := false
-var __running := false
+# Tweener for tweening properties.
+class PropertyTweener extends Tweener:
+	var _target: Object
+	var _property: NodePath
+	var _from
+	var _to
+	var _duration: float
+	var _trans: int
+	var _ease: int
+	
+	var _delay: float
+	var _continue := true
+	var _advance := false
+	
+	func _init(target: Object, property: NodePath, to_value, duration: float) -> void:
+		assert(target, "Invalid target Object.")
+		_target = target
+		_property = property
+		_from = _target.get_indexed(property)
+		_to = to_value
+		_duration = duration
+		_trans = Tween.TRANS_LINEAR
+		_ease = Tween.EASE_IN_OUT
+	
+	
+	# Sets custom starting value for the tweener.
+	# By default, it starts from value at the start of this tweener.
+	func from(val) -> PropertyTweener:
+		_from = val
+		_continue = false
+		return self
+	
+	
+	# Sets the starting value to the current value,
+	# i.e. value at the time of creating sequence.
+	func from_current() -> PropertyTweener:
+		_continue = false
+		return self
+	
+	
+	# Sets transition type of this tweener, from Tween.TransitionType.
+	func set_trans(t: int) -> PropertyTweener:
+		_trans = t
+		return self
+	
+	
+	# Sets ease type of this tweener, from Tween.EaseType.
+	func set_ease(e: int) -> PropertyTweener:
+		_ease = e
+		return self
+	
+	
+	# Sets the delay after which this tweener will start.
+	func set_delay(d: float) -> PropertyTweener:
+		_delay = d
+		return self
+	
+	
+	func _start(tween: Tween) -> void:
+		if not is_instance_valid(_target):
+			push_warning("Target object freed, aborting Tweener.")
+			return
+		
+		if _continue:
+			_from = _target.get_indexed(_property)
+		
+		if _advance:
+			tween.interpolate_property(_target, _property, _from, _from + _to, _duration, _trans, _ease, _delay)
+		else:
+			tween.interpolate_property(_target, _property, _from, _to, _duration, _trans, _ease, _delay)
 
-var __kill_when_finised := true
-var __parallel := false
 
-##Emited when one step of the sequence is finished.
+# Generic tweener for creating delays in sequence.
+class IntervalTweener extends Tweener:
+	var _time: float
+	
+	func _init(time: float) -> void:
+		_time = time
+	
+	
+	func _start(tween: Tween) -> void:
+		tween.interpolate_callback(self, _time, "_")
+	
+	
+	func _():
+		pass
+
+
+# Tweener for calling methods.
+class CallbackTweener extends Tweener:
+	var _target: Object
+	var _delay: float
+	var _method: String
+	var _args: Array
+	
+	func _init(target: Object, method: String, args: Array) -> void:
+		assert(target, "Invalid target Object.")
+		_target = target
+		_method = method
+		_args = args
+	
+	
+	# Set delay after which the method will be called.
+	func set_delay(d: float) -> CallbackTweener:
+		_delay = d
+		return self
+	
+	
+	func _start(tween: Tween) -> void:
+		if not is_instance_valid(_target):
+			push_warning("Target object freed, aborting Tweener.")
+			return
+		
+		tween.interpolate_callback(_target, _delay, _method,
+			_get_argument(0), _get_argument(1), _get_argument(2),
+			_get_argument(3), _get_argument(4))
+	
+	
+	func _get_argument(i: int):
+		if i < _args.size():
+			return _args[i]
+		else:
+			return null
+
+
+# Tweener for tweening arbitrary values using getter/setter method.
+class MethodTweener extends Tweener:
+	var _target: Object
+	var _method: String
+	var _from
+	var _to
+	var _duration: float
+	var _trans: int
+	var _ease: int
+	
+	var _delay: float
+	
+	func _init(target: Object, method: String, from_value, to_value, duration: float) -> void:
+		assert(target, "Invalid target Object.")
+		_target = target
+		_method = method
+		_from = from_value
+		_to = to_value
+		_duration = duration
+		_trans = Tween.TRANS_LINEAR
+		_ease = Tween.EASE_IN_OUT
+	
+	
+	# Sets transition type of this tweener, from Tween.TransitionType.
+	func set_trans(t: int) -> MethodTweener:
+		_trans = t
+		return self
+	
+	
+	# Sets ease type of this tweener, from Tween.EaseType.
+	func set_ease(e: int) -> MethodTweener:
+		_ease = e
+		return self
+	
+	
+	# Sets the delay after which this tweener will start.
+	func set_delay(d: float) -> MethodTweener:
+		_delay = d
+		return self
+	
+	
+	func _start(tween: Tween) -> void:
+		if not is_instance_valid(_target):
+			push_warning("Target object freed, aborting Tweener.")
+			return
+		
+		tween.interpolate_method(_target, _method, _from, _to, _duration, _trans, _ease, _delay)
+
+
+# Emited when one step of the sequence is finished.
 signal step_finished(idx)
-##Emited when a loop of the sequence is finished.
+# Emited when a loop of the sequence is finished.
 signal loop_finished()
-##Emitted when whole sequence is finished. Doesn't happen with inifnite loops.
+# Emitted when whole sequence is finished. Doesn't happen with inifnite loops.
 signal finished()
 
-##You need to provide SceneTree to be used by the sequence.
+var _tree: SceneTree
+var _tween: Tween
+var _tweeners: Array
+
+var _current_step := 0
+var _loops := 0
+var _autostart := true
+var _started := false
+var _running := false
+
+var _kill_when_finised := true
+var _parallel := false
+
+# You need to provide SceneTree to be used by the sequence.
 func _init(tree: SceneTree) -> void:
-	__tree = tree
-	__tween = Tween.new()
-	__tween.set_meta("sequence", self)
-	__tree.get_root().call_deferred("add_child", __tween)
+	_tree = tree
+	_tween = Tween.new()
+	_tween.set_meta("sequence", self)
+	_tree.get_root().call_deferred("add_child", _tween)
 	
-	__tree.connect("idle_frame", self, "start", [], CONNECT_ONESHOT)
-	__tween.connect("tween_all_completed", self, "__step_complete")
+	_tree.connect("idle_frame", self, "start", [], CONNECT_ONESHOT)
+	_tween.connect("tween_all_completed", self, "_step_complete")
 
-##All Tweener-creating methods will return the Tweeners for further chained usage.
+# All Tweener-creating methods will return the Tweeners for further chained usage.
 
-##Appends a PropertyTweener for tweening properties.
+# Appends a PropertyTweener for tweening properties.
 func append(target: Object, property: NodePath, to_value, duration: float) -> PropertyTweener:
 	var tweener := PropertyTweener.new(target, property, to_value, duration)
-	__add_tweener(tweener)
+	_add_tweener(tweener)
 	return tweener
 
 
-##Appends a PropertyTweener operating on relative values.
+# Appends a PropertyTweener operating on relative values.
 func append_advance(target: Object, property: NodePath, by_value, duration: float) -> PropertyTweener:
 	var tweener := PropertyTweener.new(target, property, by_value, duration)
-	tweener.__advance = true
-	__add_tweener(tweener)
+	tweener._advance = true
+	_add_tweener(tweener)
 	return tweener
 
 
-##Appends an IntervalTweener for creating delay intervals.
+# Appends an IntervalTweener for creating delay intervals.
 func append_interval(time: float) -> IntervalTweener:
 	var tweener := IntervalTweener.new(time)
-	__add_tweener(tweener)
+	_add_tweener(tweener)
 	return tweener
 
 
-##Appends a CallbackTweener for calling methods on target object.
+# Appends a CallbackTweener for calling methods on target object.
 func append_callback(target: Object, method: String, args := []) -> CallbackTweener:
 	var tweener := CallbackTweener.new(target, method, args)
-	__add_tweener(tweener)
+	_add_tweener(tweener)
 	return tweener
 
 
-##Appends a MethodTweener for tweening arbitrary values using methods.
+# Appends a MethodTweener for tweening arbitrary values using methods.
 func append_method(target: Object, method: String, from_value, to_value, duration: float) -> MethodTweener:
 	var tweener := MethodTweener.new(target, method, from_value, to_value, duration)
-	__add_tweener(tweener)
+	_add_tweener(tweener)
 	return tweener
 
 
-##When used, next Tweener will be added as a parallel to previous one.
-##Example: sequence.parallel().append(...)
+# When used, next Tweener will be added as a parallel to previous one.
+# Example: sequence.parallel().append(...)
 func parallel() -> TweenSequence:
-	if __tweeners.empty():
-		__tweeners.append([])
-	__parallel = true
+	if _tweeners.empty():
+		_tweeners.append([])
+	_parallel = true
 	return self
 
 
-##Alias to parallel(), except it won't work without first tweener.
+# Alias to parallel(), except it won't work without first tweener.
 func join() -> TweenSequence:
-	assert(!__tweeners.empty(), "Can't join with empty sequence!")
-	__parallel = true
+	assert(!_tweeners.empty(), "Can't join with empty sequence!")
+	_parallel = true
 	return self
 
 
-##Sets the speed scale of tweening.
+# Sets the speed scale of tweening.
 func set_speed(speed: float) -> TweenSequence:
-	__tween.playback_speed = speed
+	_tween.playback_speed = speed
 	return self
 
 
-##Sets how many the sequence should repeat.
-##When used without arguments, sequence will run infinitely.
+# Sets how many the sequence should repeat.
+# When used without arguments, sequence will run infinitely.
 func set_loops(loops := -1) -> TweenSequence:
-	__loops = loops
+	_loops = loops
 	return self
 
 
-##Whether the sequence should autostart or not.
-##Enabled by default.
+# Whether the sequence should autostart or not.
+# Enabled by default.
 func set_autostart(autostart: bool) -> TweenSequence:
-	if __autostart and not autostart:
-		__tree.disconnect("idle_frame", self, "start")
-	elif not __autostart and autostart:
-		__tree.connect("idle_frame", self, "start", [], CONNECT_ONESHOT)
+	if _autostart and not autostart:
+		_tree.disconnect("idle_frame", self, "start")
+	elif not _autostart and autostart:
+		_tree.connect("idle_frame", self, "start", [], CONNECT_ONESHOT)
 	
-	__autostart = autostart
+	_autostart = autostart
 	return self
 
 
-##Starts the sequence manually, unless it's already started.
+# Starts the sequence manually, unless it's already started.
 func start() -> void:
-	assert(__tween, "Tween was removed!")
-	assert(!__started, "Sequence already started!")
-	__started = true
-	__running = true
-	__run_next_step()
+	assert(_tween, "Tween was removed!")
+	assert(!_started, "Sequence already started!")
+	_started = true
+	_running = true
+	_run_next_step()
 
 
-##Returns whether the sequence is currently running.
+# Returns whether the sequence is currently running.
 func is_running() -> bool:
-	return __running
+	return _running
 
 
-##Pauses the execution of the tweens.
+# Pauses the execution of the tweens.
 func pause() -> void:
-	assert(__tween, "Tween was removed!")
-	assert(__running, "Sequence not running!")
-	__tween.stop_all()
-	__running = false
+	assert(_tween, "Tween was removed!")
+	assert(_running, "Sequence not running!")
+	_tween.stop_all()
+	_running = false
 
 
-##Resumes the execution of the tweens.
+# Resumes the execution of the tweens.
 func resume() -> void:
-	assert(__tween, "Tween was removed!")
-	assert(!__running, "Sequence already running!")
-	__tween.resume_all()
-	__running = true
+	assert(_tween, "Tween was removed!")
+	assert(!_running, "Sequence already running!")
+	_tween.resume_all()
+	_running = true
 
 
-##Stops the sequence and resets it to the beginning.
+# Stops the sequence and resets it to the beginning.
 func reset() -> void:
-	assert(__tween, "Tween was removed!")
-	if __running:
+	assert(_tween, "Tween was removed!")
+	if _running:
 		pause()
-	__started = false
-	__current_step = 0
-	__tween.reset_all()
+	_started = false
+	_current_step = 0
+	_tween.reset_all()
 
 
-##Frees the underlying Tween. Sequence is unusable after this operation.
+# Frees the underlying Tween. Sequence is unusable after this operation.
 func kill():
-	assert(__tween, "Tween was already removed!")
-	if __running:
+	assert(_tween, "Tween was already removed!")
+	if _running:
 		pause()
-	__tween.queue_free()
+	_tween.queue_free()
 
 
-##Whether the Tween should be freed when sequence finishes.
-##Default is true. If set to false, sequence will restart on end.
+# Whether the Tween should be freed when sequence finishes.
+# Default is true. If set to false, sequence will restart on end.
 func set_autokill(autokill: bool):
-	__kill_when_finised = autokill
+	_kill_when_finised = autokill
 
 
-func __add_tweener(tweener: Tweener):
-	assert(__tween, "Tween was removed!")
-	assert(!__started, "Can't append to a started sequence!")
-	if not __parallel:
-		__tweeners.append([])
-	__tweeners.back().append(tweener)
-	__parallel = false
+func _add_tweener(tweener: Tweener):
+	assert(_tween, "Tween was removed!")
+	assert(!_started, "Can't append to a started sequence!")
+	if not _parallel:
+		_tweeners.append([])
+	_tweeners.back().append(tweener)
+	_parallel = false
 
 
-func __run_next_step() -> void:
-	assert(!__tweeners.empty(), "Sequence has no steps!")
-	var group := __tweeners[__current_step] as Array
+func _run_next_step() -> void:
+	assert(!_tweeners.empty(), "Sequence has no steps!")
+	var group := _tweeners[_current_step] as Array
 	for tweener in group:
-		tweener.__start(__tween)
-	__tween.start()
+		tweener._start(_tween)
+	_tween.start()
 
 
-func __step_complete() -> void:
-	emit_signal("step_finished", __current_step)
-	__current_step += 1
+func _step_complete() -> void:
+	emit_signal("step_finished", _current_step)
+	_current_step += 1
 	
-	if __current_step == __tweeners.size():
-		__loops -= 1
-		if __loops == -1:
+	if _current_step == _tweeners.size():
+		_loops -= 1
+		if _loops == -1:
 			emit_signal("finished")
-			if __kill_when_finised:
+			if _kill_when_finised:
 				kill()
 			else:
 				reset()
 		else:
 			emit_signal("loop_finished")
-			__current_step = 0
-			__run_next_step()
+			_current_step = 0
+			_run_next_step()
 	else:
-		__run_next_step()
-
-
-##Abstract class for all Tweeners.
-class Tweener:
-	extends Reference
-	
-	func __start(tween: Tween) -> void:
-		pass
-
-
-##Tweener for tweening properties.
-class PropertyTweener:
-	extends Tweener
-	
-	var __target: Object
-	var __property: NodePath
-	var __from
-	var __to
-	var __duration: float
-	var __trans: int
-	var __ease: int
-	
-	var __delay: float
-	var __continue := true
-	var __advance := false
-	
-	func _init(target: Object, property: NodePath, to_value, duration: float) -> void:
-		assert(target, "Invalid target Object.")
-		__target = target
-		__property = property
-		__from = __target.get_indexed(property)
-		__to = to_value
-		__duration = duration
-		__trans = Tween.TRANS_LINEAR
-		__ease = Tween.EASE_IN_OUT
-	
-	
-	##Sets custom starting value for the tweener.
-	##By default, it starts from value at the start of this tweener.
-	func from(val) -> PropertyTweener:
-		__from = val
-		__continue = false
-		return self
-	
-	
-	##Sets the starting value to the current value,
-	##i.e. value at the time of creating sequence.
-	func from_current() -> PropertyTweener:
-		__continue = false
-		return self
-	
-	
-	##Sets transition type of this tweener, from Tween.TransitionType.
-	func set_trans(t: int) -> PropertyTweener:
-		__trans = t
-		return self
-	
-	
-	##Sets ease type of this tweener, from Tween.EaseType.
-	func set_ease(e: int) -> PropertyTweener:
-		__ease = e
-		return self
-	
-	
-	##Sets the delay after which this tweener will start.
-	func set_delay(d: float) -> PropertyTweener:
-		__delay = d
-		return self
-	
-	
-	func __start(tween: Tween) -> void:
-		if not is_instance_valid(__target):
-			push_warning("Target object freed, aborting Tweener.")
-			return
-		
-		if __continue:
-			__from = __target.get_indexed(__property)
-		
-		if __advance:
-			tween.interpolate_property(__target, __property, __from, __from + __to, __duration, __trans, __ease, __delay)
-		else:
-			tween.interpolate_property(__target, __property, __from, __to, __duration, __trans, __ease, __delay)
-
-
-##Generic tweener for creating delays in sequence.
-class IntervalTweener:
-	extends Tweener
-	
-	var __time: float
-	
-	func _init(time: float) -> void:
-		__time = time
-	
-	
-	func __start(tween: Tween) -> void:
-		tween.interpolate_callback(self, __time, "__")
-	
-	
-	func __():
-		pass
-
-
-##Tweener for calling methods.
-class CallbackTweener:
-	extends Tweener
-	
-	var __target: Object
-	var __delay: float
-	var __method: String
-	var __args: Array
-	
-	func _init(target: Object, method: String, args: Array) -> void:
-		assert(target, "Invalid target Object.")
-		__target = target
-		__method = method
-		__args = args
-	
-	##Set delay after which the method will be called.
-	func set_delay(d: float) -> CallbackTweener:
-		__delay = d
-		return self
-	
-	
-	func __start(tween: Tween) -> void:
-		if not is_instance_valid(__target):
-			push_warning("Target object freed, aborting Tweener.")
-			return
-		
-		tween.interpolate_callback(__target, __delay, __method,
-			__get_argument(0), __get_argument(1), __get_argument(2),
-			__get_argument(3), __get_argument(4))
-	
-	
-	func __get_argument(i: int):
-		if i < __args.size():
-			return __args[i]
-		else:
-			return null
-
-##Tweener for tweening arbitrary values using getter/setter method.
-class MethodTweener:
-	extends Tweener
-	
-	var __target: Object
-	var __method: String
-	var __from
-	var __to
-	var __duration: float
-	var __trans: int
-	var __ease: int
-	
-	var __delay: float
-	
-	func _init(target: Object, method: String, from_value, to_value, duration: float) -> void:
-		assert(target, "Invalid target Object.")
-		__target = target
-		__method = method
-		__from = from_value
-		__to = to_value
-		__duration = duration
-		__trans = Tween.TRANS_LINEAR
-		__ease = Tween.EASE_IN_OUT
-	
-	
-	##Sets transition type of this tweener, from Tween.TransitionType.
-	func set_trans(t: int) -> MethodTweener:
-		__trans = t
-		return self
-	
-	
-	##Sets ease type of this tweener, from Tween.EaseType.
-	func set_ease(e: int) -> MethodTweener:
-		__ease = e
-		return self
-	
-	
-	##Sets the delay after which this tweener will start.
-	func set_delay(d: float) -> MethodTweener:
-		__delay = d
-		return self
-	
-	
-	func __start(tween: Tween) -> void:
-		if not is_instance_valid(__target):
-			push_warning("Target object freed, aborting Tweener.")
-			return
-		
-		tween.interpolate_method(__target, __method, __from, __to, __duration, __trans, __ease, __delay)
+		_run_next_step()

--- a/addons/godot-next/resources/behavior.gd
+++ b/addons/godot-next/resources/behavior.gd
@@ -1,4 +1,6 @@
-# Behavior
+tool
+class_name Behavior
+extends Resource
 # author: xdgamestudios
 # license: MIT
 # description:
@@ -17,17 +19,6 @@
 #	Note:
 #		- If present notifications, are automatically triggered by the owner class.
 #		- If the behavior is disabled its notifications will not be processed. 
-tool
-extends Resource
-class_name Behavior
-
-##### CLASSES #####
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
-
-##### PROPERTIES #####
 
 # A reference to the owning Behaviors node.
 var owner: Node = null setget set_owner, get_owner
@@ -35,40 +26,25 @@ var owner: Node = null setget set_owner, get_owner
 # Allows users to toggle processing callbacks on the owner.
 var enabled: bool = true setget set_enabled, get_enabled
 
-##### NOTIFICATIONS #####
-
-##### OVERRIDES #####
-
-##### VIRTUALS #####
-
-# '_awake' name is used to match the convention in Unity's MonoBehaviour class.
+# This name is used to match the convention in Unity's MonoBehaviour class.
 func _awake() -> void:
 	pass
 
-# '_on_enable' name is used to match the convention in Unity's MonoBehaviour class.
+
+# This name is used to match the convention in Unity's MonoBehaviour class.
 func _on_enable() -> void:
 	pass
-	
-# '_on_disable' name is used to match the convention in Unity's MonoBehaviour class.
+
+
+# This name is used to match the convention in Unity's MonoBehaviour class.
 func _on_disable() -> void:
 	pass
 
-# Should only override if one wishes to create their own abstract Behaviors
-# By default, the absence of this method is interpreted as a non-abstract type!
-static func is_abstract() -> bool:
-	return true
-
-##### PUBLIC METHODS #####
 
 # Returns an instance of the stored Behavior resource from the owner.
 func get_behavior(p_type: Script) -> Behavior:
 	return owner.get_element(p_type)
 
-##### PRIVATE METHODS #####
-
-##### CONNECTIONS #####
-
-##### SETTERS AND GETTERS #####
 
 func set_enabled(p_enable: bool) -> void:
 	if enabled == p_enable:
@@ -93,3 +69,9 @@ func set_owner(p_owner: Node) -> void:
 
 func get_owner() -> Node:
 	return owner
+
+
+# Should only override if one wishes to create their own abstract Behaviors
+# By default, the absence of this method is interpreted as a non-abstract type!
+static func is_abstract() -> bool:
+	return true

--- a/addons/godot-next/resources/discrete_gradient_texture.gd
+++ b/addons/godot-next/resources/discrete_gradient_texture.gd
@@ -1,43 +1,25 @@
-# DiscreteGradientTexture
+tool
+class_name DiscreteGradientTexture
+extends ImageTexture
 # author: Athrunen
 # license: MIT
 # description: Has the same functionality as the GradientTexture but does not interpolate colors.
 # todos:
-#	- Write a more elegant way of updating the texture than changing the resolution
-#	- Persuade godot to repeat the texture vertically in the inspector
-tool
-extends ImageTexture
-class_name DiscreteGradientTexture
+#	- Write a more elegant way of updating the texture than changing the resolution.
+#	- Persuade Godot to repeat the texture vertically in the inspector.
 
-##### CLASSES #####
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
-
-##### PROPERTIES #####
-
-export var resolution : int = 256 setget _update_resolution 
-export var gradient : Gradient = Gradient.new() setget _update_gradient
-
-##### NOTIFICATIONS #####
+export var resolution: int = 256 setget _update_resolution 
+export var gradient: Gradient = Gradient.new() setget _update_gradient
 
 func _ready() -> void:
 	_update_texture()
 
-##### OVERRIDES #####
-
-##### VIRTUALS #####
-
-##### PUBLIC METHODS #####
-
-##### PRIVATE METHODS #####
 
 func _update_texture() -> void:
 	var image := Image.new()
 	image.create(resolution, 1, false, Image.FORMAT_RGBA8)
 	
-	if (not gradient):
+	if not gradient:
 		return
 	
 	image.lock()
@@ -64,9 +46,6 @@ func _update_texture() -> void:
 	image.unlock()
 	self.create_from_image(image, 0)
 
-##### CONNECTIONS #####
-
-##### SETTERS AND GETTERS #####
 
 func _update_gradient(g: Gradient) -> void:
 	gradient = g

--- a/addons/godot-next/resources/resource_collections/resource_array.gd
+++ b/addons/godot-next/resources/resource_collections/resource_array.gd
@@ -1,4 +1,6 @@
-# ResourceArray
+tool
+class_name ResourceArray
+extends ResourceCollection
 # author: xdgamestudios
 # license: MIT
 # description:
@@ -7,26 +9,21 @@
 # deps:
 #	- ResourceCollection
 #	- PropertyInfo
-tool
-extends ResourceCollection
-class_name ResourceArray
-
-##### CLASSES #####
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
 
 const COLLECTION_NAME = "[ Array ]"
 
-##### PROPERTIES #####
-
 var _data := []
-
-##### NOTIFICATIONS #####
 
 func _init() -> void:
 	resource_name = COLLECTION_NAME
+
+
+func clear() -> void:
+	_data.clear()
+
+
+func get_data() -> Array:
+	return _data
 
 
 func _get(p_property: String):
@@ -51,7 +48,6 @@ func _set(p_property, p_value):
 		return true
 	return false
 
-##### OVERRIDES #####
 
 func _add_element(script) -> void:
 	_data.append(script.new())
@@ -75,19 +71,3 @@ func _export_data_group() -> Array:
 	for an_index in _data.size():
 		list.append(PropertyInfo.new_resource("%sitem_%s" % [DATA_PREFIX, an_index], "", PROPERTY_USAGE_EDITOR).to_dict())
 	return list
-
-##### VIRTUALS #####
-
-##### PUBLIC METHODS #####
-
-func clear() -> void:
-	_data.clear()
-
-##### PRIVATE METHODS #####
-
-##### CONNECTIONS #####
-
-##### SETTERS AND GETTERS #####
-
-func get_data() -> Array:
-	return _data

--- a/addons/godot-next/resources/resource_collections/resource_collection.gd
+++ b/addons/godot-next/resources/resource_collections/resource_collection.gd
@@ -1,32 +1,46 @@
-# ResourceCollection
+tool
+class_name ResourceCollection
+extends Resource
 # author: xdgamestudios
 # license: MIT
 # description:
 #	An abstract base class for data structures that store Resource objects.
 #	Uses a key-value store, but can also append items.
-tool
-extends Resource
-class_name ResourceCollection
-
-##### CLASSES #####
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
 
 const SETUP_PREFIX = "setup/"
 const DATA_PREFIX = "data/"
 
 const EMPTY_ENTRY = "[ Empty ]"
 
-##### PROPERTIES #####
-
 var _type: Script = null
 var _type_readonly: bool = false
-#warning-ignore:unused_class_variable
 var _class_type: ClassType = ClassType.new()
 
-##### NOTIFICATIONS #####
+func clear() -> void:
+	assert(false)
+
+
+func get_base_type() -> Script:
+	return _type
+
+
+func set_base_type(p_type: Script) -> void:
+	if _type == p_type:
+		return
+	_type = p_type
+	property_list_changed_notify()
+
+
+func is_type_readonly() -> bool:
+	return _type_readonly
+
+
+func set_type_readonly(read_only: bool) -> void:
+	if _type_readonly == read_only:
+		return
+	_type_readonly = read_only
+	property_list_changed_notify()
+
 
 func _get(p_property: String):
 	match p_property.trim_prefix(SETUP_PREFIX):
@@ -55,9 +69,6 @@ func _get_property_list() -> Array:
 	list += _export_data_group()
 	return list
 
-##### OVERRIDES #####
-
-##### VIRTUALS #####
 
 # Append an element to the collection.
 #warning-ignore:unused_argument
@@ -70,17 +81,17 @@ func _refresh_data() -> void:
 	assert(false)
 
 
-# Export properties within the 'data' group
+# Export properties within the 'data' group.
 func _export_data_group() -> Array:
 	return [ PropertyInfo.new_editor_only(DATA_PREFIX + "dropdown").to_dict() ]
 
 
-# Export properties within the 'setup' group
+# Export properties within the 'setup' group.
 func _export_setup_group() -> Array:
 	return [ PropertyInfo.new_resource(SETUP_PREFIX + "base_type", "Script").to_dict() ] if not _type_readonly else []
 
 
-# Injects controls to the 'EditorInspectorPlugin'
+# Injects controls to the EditorInspectorPlugin.
 func _parse_property(p_plugin: EditorInspectorPlugin, p_pinfo: PropertyInfo) -> bool:
 	match p_pinfo.name.trim_prefix(DATA_PREFIX):
 		"dropdown":
@@ -90,12 +101,6 @@ func _parse_property(p_plugin: EditorInspectorPlugin, p_pinfo: PropertyInfo) -> 
 			return true
 	return false
 
-##### PUBLIC METHODS #####
-
-func clear() -> void:
-	assert(false)
-
-##### PRIVATE METHODS #####
 
 func _instantiate_script(p_script: Script) -> Resource:
 	var res: Resource = null
@@ -116,32 +121,8 @@ func _find_inheritors() -> Dictionary:
 		inheritors[a_name] = load(type_map[a_name].path)
 	return inheritors
 
-##### CONNECTIONS #####
 
 func _on_dropdown_selector_selected(dropdown_selector):
 	var script = dropdown_selector.get_selected_meta()
 	_add_element(script)
-	property_list_changed_notify()
-
-##### SETTERS AND GETTERS #####
-
-func get_base_type() -> Script:
-	return _type
-
-
-func set_base_type(p_type: Script) -> void:
-	if _type == p_type:
-		return
-	_type = p_type
-	property_list_changed_notify()
-
-
-func is_type_readonly() -> bool:
-	return _type_readonly
-
-
-func set_type_readonly(read_only: bool) -> void:
-	if _type_readonly == read_only:
-		return
-	_type_readonly = read_only
 	property_list_changed_notify()

--- a/addons/godot-next/resources/resource_collections/resource_set.gd
+++ b/addons/godot-next/resources/resource_collections/resource_set.gd
@@ -1,4 +1,6 @@
-# ResourceSet
+tool
+class_name ResourceSet
+extends ResourceCollection
 # author: xdgamestudios
 # license: MIT
 # description:
@@ -7,26 +9,21 @@
 # deps:
 #	- ResourceCollection
 #	- PropertyInfo
-tool
-extends ResourceCollection
-class_name ResourceSet
-
-##### CLASSES #####
-
-##### SIGNALS #####
-
-##### CONSTANTS #####
 
 const COLLECTION_NAME: String = "[ Set ]"
 
-##### PROPERTIES #####
-
 var _data: Dictionary = {}
-
-##### NOTIFICATIONS #####
 
 func _init() -> void:
 	resource_name = COLLECTION_NAME
+
+
+func clear() -> void:
+	_data.clear()
+
+
+func get_data() -> Dictionary:
+	return _data
 
 
 func _get(p_property: String):
@@ -51,7 +48,6 @@ func _set(p_property: String, p_value) -> bool:
 		return true
 	return false
 
-##### OVERRIDES #####
 
 func _add_element(p_script: Script) -> void:
 	_class_type.res = p_script
@@ -80,19 +76,3 @@ func _export_data_group() -> Array:
 	for a_typename in _data:
 		list.append(PropertyInfo.new_resource(DATA_PREFIX + a_typename, "", PROPERTY_USAGE_EDITOR).to_dict())
 	return list
-
-##### VIRTUALS #####
-
-##### PUBLIC METHODS #####
-
-func clear() -> void:
-	_data.clear()
-
-##### PRIVATE METHODS #####
-
-##### CONNECTIONS #####
-
-##### SETTERS AND GETTERS #####
-
-func get_data() -> Dictionary:
-	return _data

--- a/addons/godot-next/resources/singletons/singleton_cache.gd
+++ b/addons/godot-next/resources/singletons/singleton_cache.gd
@@ -1,17 +1,13 @@
+tool
+extends Resource
 # author: xdgamestudios
 # license: MIT
 # description:
 #	A resource file that is preloaded into memory to allow for accessing
 #	singleton classes project wide using Singletons
-tool
-extends Resource
-
-##### PROPERTIES #####
 
 var _cache: Dictionary = {}
 var _paths: Dictionary = {}
-
-##### PUBLIC METHODS #####
 
 func get_cache() -> Dictionary:
 	return _cache

--- a/addons/godot-next/singletons/icons.gd
+++ b/addons/godot-next/singletons/icons.gd
@@ -1,13 +1,12 @@
-# Icons
+tool
+class_name Icons
+extends Reference
 # author: willnationsdev
 # license: MIT
 # description:
 #	A singleton that stores paths to icons, but fetches them loaded for users.
 #	icons must have a `icon_<name>.svg` file path, anywhere in the project.
 #	The name can then be accessed directly as a property of Icons.fetch().
-tool
-extends Reference
-class_name Icons
 
 const SELF_PATH: String = "res://addons/godot-next/singletons/icons.gd"
 

--- a/project.godot
+++ b/project.godot
@@ -57,7 +57,7 @@ _global_script_classes=[ {
 "base": "ImageTexture",
 "class": "DiscreteGradientTexture",
 "language": "GDScript",
-"path": "res://addons/godot-next/resources/DiscreteGradientTexture.gd"
+"path": "res://addons/godot-next/resources/discrete_gradient_texture.gd"
 }, {
 "base": "Reference",
 "class": "EditorTools",


### PR DESCRIPTION
This PR changes the scripts to conform to the [GDScript style guide](https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_styleguide.html). Some notes:

The `#####` markers have been removed, since the sorting order is now standardized, it should be easy to find anything for users familiar with the style guide.

There are a few things missing from the style guide, such as how to sort static functions and in-file classes. For classes, I moved them to the top; for static functions, I left them as-is.

I also fixed some issues with methods conflicting with Godot's build-in method names. `variant.gd`'s `to_string` is now `var_to_string`, and `csv_file.gd`'s `load` and `save` are now `load_file` and `save_file`. I also changed `physics_layers.gd`'s 2D/3D distinction to a boolean. That should be all of the public API changes in this PR.