### PR TITLE
Add VectorDisplay2D and VectorDisplay3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ That's it! I hope you've got ideas of what you'd like to share with others.
 |[Trail2D](addons/godot-next/2d/trail_2d.gd)|Creates a variable-length trail that tracks a "target" node.|GDScript, C#
 |[Trail3D](addons/godot-next/3d/trail_3d.gd)|Creates a variable-length trail on an ImmediateGeometry node.|GDScript, C#
 |[Tween Sequence](addons/godot-next/references/tween_sequence.gd)|A helper class for easier management and chaining of Tweens dynamically from code.|GDScript
+|[VectorDisplay2D](addons/godot-next/2d/vector_display_2d.gd)|Displays Vector2 members in the editor via Position2D nodes.|GDScript
+|[VectorDisplay3D](addons/godot-next/3d/vector_display_3d.gd)|Displays Vector3 members in the editor via Position3D nodes.|GDScript
 |[Variant](addons/godot-next/global/variant.gd)|A utility class for handling Variants (the type wrapper for all variables in Godot's scripting API).|GDScript
 |[VBoxItemList](addons/godot-next/gui/v_box_item_list.gd)|Creates a vertical list of items that can be added or removed. Items are a user-specified Script or Scene Control.|GDScript
 |[DiscreteGradientTexture](addons/godot-next/resources/DiscreteGradientTexture.gd)|Creates a not interpolated texture for a gradient.|GDScript

--- a/addons/godot-next/2d/vector_display_2d.gd
+++ b/addons/godot-next/2d/vector_display_2d.gd
@@ -1,0 +1,54 @@
+tool
+class_name VectorDisplay2D
+extends Node
+# Displays Vector2 members in the editor via Position2D nodes.
+
+export(String) var variable_name = ""
+export(bool) var relative = true
+
+var _old_variable_name = null
+var _storage: Node2D
+
+
+func _process(delta):
+	if not variable_name:
+		if _old_variable_name != variable_name:
+			_old_variable_name = variable_name
+			printerr("VectorDisplay2D: Please provide a variable name.")
+		return
+	
+	if not _storage:
+		_storage = Node2D.new()
+		get_tree().get_edited_scene_root().add_child(_storage)
+		return
+	
+	for child in _storage.get_children():
+		child.queue_free()
+	
+	var parent = get_parent()
+	if relative:
+		_storage.transform.origin = parent.global_transform.origin
+	else:
+		_storage.transform.origin = Vector2.ZERO
+	
+	var variable = parent.get(variable_name)
+	if variable == null:
+		if _old_variable_name != variable_name:
+			_old_variable_name = variable_name
+			printerr("VectorDisplay2D: Variable '" + variable_name + "' not found or invalid on parent node '" + get_parent().get_name() + "'.")
+	elif variable is Vector2:
+		_add_position_child(variable)
+	elif variable is PoolVector2Array:
+		for item in variable:
+			_add_position_child(item)
+	elif variable is Array:
+		for item in variable:
+			if item is Vector2:
+				_add_position_child(item)
+
+
+func _add_position_child(vector):
+	var node = Position2D.new()
+	node.transform.origin = vector
+	_storage.add_child(node)
+	node.set_owner(get_tree().get_edited_scene_root())

--- a/addons/godot-next/3d/vector_display_3d.gd
+++ b/addons/godot-next/3d/vector_display_3d.gd
@@ -1,0 +1,54 @@
+tool
+class_name VectorDisplay3D
+extends Node
+# Displays Vector3 members in the editor via Position3D nodes.
+
+export(String) var variable_name = ""
+export(bool) var relative = true
+
+var _old_variable_name = null
+var _storage: Spatial
+
+
+func _process(delta):
+	if not variable_name:
+		if _old_variable_name != variable_name:
+			_old_variable_name = variable_name
+			printerr("VectorDisplay3D: Please provide a variable name.")
+		return
+	
+	if not _storage:
+		_storage = Spatial.new()
+		get_tree().get_edited_scene_root().add_child(_storage)
+		return
+	
+	for child in _storage.get_children():
+		child.queue_free()
+	
+	var parent = get_parent()
+	if relative:
+		_storage.transform.origin = parent.global_transform.origin
+	else:
+		_storage.transform.origin = Vector3.ZERO
+	
+	var variable = parent.get(variable_name)
+	if variable == null:
+		if _old_variable_name != variable_name:
+			_old_variable_name = variable_name
+			printerr("VectorDisplay3D: Variable '" + variable_name + "' not found or invalid on parent node '" + get_parent().get_name() + "'.")
+	elif variable is Vector3:
+		_add_position_child(variable)
+	elif variable is PoolVector3Array:
+		for item in variable:
+			_add_position_child(item)
+	elif variable is Array:
+		for item in variable:
+			if item is Vector3:
+				_add_position_child(item)
+
+
+func _add_position_child(vector):
+	var node = Position3D.new()
+	node.transform.origin = vector
+	_storage.add_child(node)
+	node.set_owner(get_tree().get_edited_scene_root())

--- a/demo/demo_2d.tscn
+++ b/demo/demo_2d.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/godot-next/2d/geometry_2d.gd" type="Script" id=1]
 [ext_resource path="res://addons/godot-next/2d/trail_2d.gd" type="Script" id=2]
 [ext_resource path="res://addons/godot-next/gui/debug_label.gd" type="Script" id=3]
+[ext_resource path="res://addons/godot-next/2d/vector_display_2d.gd" type="Script" id=4]
 [ext_resource path="res://demo/scripts/wandering_node_2d.gd" type="Script" id=5]
+[ext_resource path="res://demo/scripts/test_vector_display.gd" type="Script" id=6]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 50.0
@@ -45,8 +47,17 @@ script = ExtResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+update_mode = 0
 target_path = NodePath("../WanderingNode2D")
 show_label_name = true
 show_target_name = true
 properties = PoolStringArray( "position", "velocity", "name" )
-update_mode = 0
+
+[node name="TestVectorDisplay2D" type="Node2D" parent="."]
+position = Vector2( 100, 100 )
+script = ExtResource( 6 )
+pool_vector2_array = PoolVector2Array( 100, 200, 200, 100 )
+
+[node name="VectorDisplay2D" type="Node" parent="TestVectorDisplay2D"]
+script = ExtResource( 4 )
+variable_name = "pool_vector2_array"

--- a/demo/demo_3d.tscn
+++ b/demo/demo_3d.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://addons/godot-next/3d/trail_3d.gd" type="Script" id=1]
 [ext_resource path="res://demo/scripts/wandering_node_3d.gd" type="Script" id=2]
+[ext_resource path="res://addons/godot-next/3d/vector_display_3d.gd" type="Script" id=3]
+[ext_resource path="res://demo/scripts/test_vector_display.gd" type="Script" id=4]
 
 [node name="Demo3D" type="Spatial"]
 
@@ -17,3 +19,12 @@ density_around = 20
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 2, 8 )
+
+[node name="TestVectorDisplay3D" type="Spatial" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 0, 0.5 )
+script = ExtResource( 4 )
+pool_vector3_array = PoolVector3Array( 1, 0, 2, 2, 0, 1 )
+
+[node name="VectorDisplay3D" type="Node" parent="TestVectorDisplay3D"]
+script = ExtResource( 3 )
+variable_name = "pool_vector3_array"

--- a/demo/scripts/test_vector_display.gd
+++ b/demo/scripts/test_vector_display.gd
@@ -1,0 +1,7 @@
+extends Node
+
+export(Vector2) var vector2 = Vector2(100, 200)
+export(Vector3) var vector3 = Vector3(1, 2, 3)
+export(PoolVector2Array) var pool_vector2_array = PoolVector2Array()
+export(PoolVector3Array) var pool_vector3_array = PoolVector3Array()
+export(Array) var array = [Vector2(100, 100), Vector3(0, 1, 2)]

--- a/project.godot
+++ b/project.godot
@@ -163,6 +163,16 @@ _global_script_classes=[ {
 "class": "Variant",
 "language": "GDScript",
 "path": "res://addons/godot-next/global/variant.gd"
+}, {
+"base": "Node",
+"class": "VectorDisplay2D",
+"language": "GDScript",
+"path": "res://addons/godot-next/2d/vector_display_2d.gd"
+}, {
+"base": "Node",
+"class": "VectorDisplay3D",
+"language": "GDScript",
+"path": "res://addons/godot-next/3d/vector_display_3d.gd"
 } ]
 _global_script_class_icons={
 "Array2D": "",
@@ -195,7 +205,9 @@ _global_script_class_icons={
 "Trail3D": "res://addons/godot-next/icons/icon_trail_3d.svg",
 "TweenSequence": "",
 "VBoxItemList": "res://addons/godot-next/icons/icon_v_box_item_list.svg",
-"Variant": ""
+"Variant": "",
+"VectorDisplay2D": "",
+"VectorDisplay3D": ""
 }
 
 [application]


### PR DESCRIPTION
This was inspired by a discussion on Discord, where a user wanted the ability to view vectors, but we wanted the avoid the inefficiency of having many node children.

You simply add VectorDisplay2D as a child of a Node2D, or VectorDisplay3D as a child of a Spatial, and specify the name of the variable to grab the information from. It can be a single vector, a PoolArray, or a GDScript array. You can also set whether or not to display relative to the parent.

In this image (the example included in the Demo3D scene), the VectorDisplay3D child is grabbing the vector information from the PoolVector3Array on its TestVectorDisplay3D parent.

![Screenshot from 2020-05-22 06-01-31](https://user-images.githubusercontent.com/1646875/82657305-2480cb00-9bf3-11ea-873f-a6dd4447390e.png)
