### PR TITLE
Fixed invalid call on base Nil

### DIFF
--- a/addons/godot-next/inspector_plugins/delegation_inspector_plugin.gd
+++ b/addons/godot-next/inspector_plugins/delegation_inspector_plugin.gd
@@ -27,7 +27,7 @@ func parse_category(p_object: Object, p_category: String) -> void:
 
 
 func parse_property(p_object: Object, p_type: int, p_path: String, p_hint: int, p_hint_text: String, p_usage: int) -> bool:
-	if p_object.has_method("_parse_property"):
+	if p_object and p_object.has_method("_parse_property"):
 		var pinfo = PropertyInfo.new(p_path, p_type, p_hint, p_hint_text, p_usage)
 		return p_object._parse_property(self, pinfo)
 	return false


### PR DESCRIPTION
Opening the `Demo2D` scene and clicking on `TestVectorDisplay2D` generates the following:

```
SCRIPT ERROR: parse_property: Invalid call. Nonexistent function 'has_method' in base 'Nil'.
   At: res://addons/godot-next/inspector_plugins/delegation_inspector_plugin.gd:30.
```

This patch fixes that.