### PR TITLE
Removed cyclic PropertyInfo references and added PropertyInfoFactory

### DIFF
--- a/addons/godot-next/nodes/callback_delegator.gd
+++ b/addons/godot-next/nodes/callback_delegator.gd
@@ -149,7 +149,7 @@ func _parse_property(p_inspector: EditorInspectorPlugin, p_pinfo: PropertyInfo) 
 
 
 func _get_property_list() -> Array:
-	return [ PropertyInfo.new_resource("_elements").to_dict() ]
+	return [ PropertyInfoFactory.new_resource("_elements").to_dict() ]
 
 
 # Helper method to facilitate delegation of the callback.

--- a/addons/godot-next/references/property_info.gd
+++ b/addons/godot-next/references/property_info.gd
@@ -8,8 +8,6 @@ extends Reference
 #	Dictionaries, of which Object._get_property_list()
 #	returns an Array.
 
-const SELF_PATH: String = "res://addons/godot-next/references/property_info.gd"
-
 var name: String
 var type: int
 var hint: int
@@ -34,38 +32,3 @@ func to_dict() -> Dictionary:
 	}
 
 
-static func from_dict(p_dict: Dictionary) -> PropertyInfo:
-	var name: String = p_dict.name if p_dict.has("name") else ""
-	var type: int = p_dict.type if p_dict.has("type") else TYPE_NIL
-	var hint: int = p_dict.hint if p_dict.has("hint") else PROPERTY_HINT_NONE
-	var hint_string: String = p_dict.hint_string if p_dict.has("hint_string") else ""
-	var usage: int = p_dict.usage if p_dict.has("usage") else PROPERTY_USAGE_DEFAULT
-	return load(SELF_PATH).new(name, type, hint, hint_string, usage)
-
-
-static func new_nil(p_name: String) -> PropertyInfo:
-	return load(SELF_PATH).new(p_name, TYPE_NIL, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR)
-
-
-static func new_group(p_name: String, p_prefix: String = "") -> PropertyInfo:
-	return load(SELF_PATH).new(p_name, TYPE_NIL, PROPERTY_HINT_NONE, p_prefix, PROPERTY_USAGE_GROUP)
-
-
-static func new_array(p_name: String, p_hint: int = PROPERTY_HINT_NONE, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> PropertyInfo:
-	return load(SELF_PATH).new(p_name, TYPE_ARRAY, p_hint, p_hint_string, p_usage)
-
-
-static func new_dictionary(p_name: String, p_hint: int = PROPERTY_HINT_NONE, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> PropertyInfo:
-	return load(SELF_PATH).new(p_name, TYPE_DICTIONARY, p_hint, p_hint_string, p_usage)
-
-
-static func new_resource(p_name: String, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> PropertyInfo:
-	return load(SELF_PATH).new(p_name, TYPE_OBJECT, PROPERTY_HINT_RESOURCE_TYPE, p_hint_string, p_usage)
-
-
-static func new_editor_only(p_name: String):
-	return load(SELF_PATH).new(p_name, TYPE_NIL, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE)
-
-
-static func new_storage_only(p_name: String):
-	return load(SELF_PATH).new(p_name, TYPE_NIL, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_SCRIPT_VARIABLE)

--- a/addons/godot-next/references/property_info_factory.gd
+++ b/addons/godot-next/references/property_info_factory.gd
@@ -1,0 +1,39 @@
+tool
+class_name PropertyInfoFactory
+extends Reference
+
+static func from_dict(p_dict: Dictionary) -> Reference:
+	var name: String = p_dict.name if p_dict.has("name") else ""
+	var type: int = p_dict.type if p_dict.has("type") else TYPE_NIL
+	var hint: int = p_dict.hint if p_dict.has("hint") else PROPERTY_HINT_NONE
+	var hint_string: String = p_dict.hint_string if p_dict.has("hint_string") else ""
+	var usage: int = p_dict.usage if p_dict.has("usage") else PROPERTY_USAGE_DEFAULT
+	return PropertyInfo.new(name, type, hint, hint_string, usage)
+
+
+static func new_nil(p_name: String) -> Reference:
+	return PropertyInfo.new(p_name, TYPE_NIL, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR)
+
+
+static func new_group(p_name: String, p_prefix: String = "") -> Reference:
+	return PropertyInfo.new(p_name, TYPE_NIL, PROPERTY_HINT_NONE, p_prefix, PROPERTY_USAGE_GROUP)
+
+
+static func new_array(p_name: String, p_hint: int = PROPERTY_HINT_NONE, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> Reference:
+	return PropertyInfo.new(p_name, TYPE_ARRAY, p_hint, p_hint_string, p_usage)
+
+
+static func new_dictionary(p_name: String, p_hint: int = PROPERTY_HINT_NONE, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> Reference:
+	return PropertyInfo.new(p_name, TYPE_DICTIONARY, p_hint, p_hint_string, p_usage)
+
+
+static func new_resource(p_name: String, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> Reference:
+	return PropertyInfo.new(p_name, TYPE_OBJECT, PROPERTY_HINT_RESOURCE_TYPE, p_hint_string, p_usage)
+
+
+static func new_editor_only(p_name: String):
+	return PropertyInfo.new(p_name, TYPE_NIL, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_SCRIPT_VARIABLE)
+
+
+static func new_storage_only(p_name: String):
+	return PropertyInfo.new(p_name, TYPE_NIL, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_SCRIPT_VARIABLE)

--- a/addons/godot-next/resources/resource_collections/resource_array.gd
+++ b/addons/godot-next/resources/resource_collections/resource_array.gd
@@ -65,9 +65,9 @@ func _refresh_data() -> void:
 
 func _export_data_group() -> Array:
 	var list := ._export_data_group()
-	list.append(PropertyInfo.new_storage_only("_data").to_dict())
+	list.append(PropertyInfoFactory.new_storage_only("_data").to_dict())
 	if _data.empty():
-		list.append(PropertyInfo.new_nil(DATA_PREFIX + EMPTY_ENTRY).to_dict())
+		list.append(PropertyInfoFactory.new_nil(DATA_PREFIX + EMPTY_ENTRY).to_dict())
 	for an_index in _data.size():
-		list.append(PropertyInfo.new_resource("%sitem_%s" % [DATA_PREFIX, an_index], "", PROPERTY_USAGE_EDITOR).to_dict())
+		list.append(PropertyInfoFactory.new_resource("%sitem_%s" % [DATA_PREFIX, an_index], "", PROPERTY_USAGE_EDITOR).to_dict())
 	return list

--- a/addons/godot-next/resources/resource_collections/resource_collection.gd
+++ b/addons/godot-next/resources/resource_collections/resource_collection.gd
@@ -83,12 +83,12 @@ func _refresh_data() -> void:
 
 # Export properties within the 'data' group.
 func _export_data_group() -> Array:
-	return [ PropertyInfo.new_editor_only(DATA_PREFIX + "dropdown").to_dict() ]
+	return [ PropertyInfoFactory.new_editor_only(DATA_PREFIX + "dropdown").to_dict() ]
 
 
 # Export properties within the 'setup' group.
 func _export_setup_group() -> Array:
-	return [ PropertyInfo.new_resource(SETUP_PREFIX + "base_type", "Script").to_dict() ] if not _type_readonly else []
+	return [ PropertyInfoFactory.new_resource(SETUP_PREFIX + "base_type", "Script").to_dict() ] if not _type_readonly else []
 
 
 # Injects controls to the EditorInspectorPlugin.

--- a/addons/godot-next/resources/resource_collections/resource_set.gd
+++ b/addons/godot-next/resources/resource_collections/resource_set.gd
@@ -70,9 +70,9 @@ func _refresh_data() -> void:
 
 func _export_data_group() -> Array:
 	var list := ._export_data_group()
-	list.append(PropertyInfo.new_storage_only("_data").to_dict())
+	list.append(PropertyInfoFactory.new_storage_only("_data").to_dict())
 	if _data.empty():
-		list.append(PropertyInfo.new_nil(DATA_PREFIX + EMPTY_ENTRY).to_dict())
+		list.append(PropertyInfoFactory.new_nil(DATA_PREFIX + EMPTY_ENTRY).to_dict())
 	for a_typename in _data:
-		list.append(PropertyInfo.new_resource(DATA_PREFIX + a_typename, "", PROPERTY_USAGE_EDITOR).to_dict())
+		list.append(PropertyInfoFactory.new_resource(DATA_PREFIX + a_typename, "", PROPERTY_USAGE_EDITOR).to_dict())
 	return list

--- a/addons/godot-next/singletons/icons.gd
+++ b/addons/godot-next/singletons/icons.gd
@@ -35,7 +35,7 @@ func register_dir(p_path: String) -> void:
 func _get_property_list():
 	var list := []
 	for a_name in data:
-		list.append(PropertyInfo.new_resource(a_name, "Texture").to_dict())
+		list.append(PropertyInfoFactory.new_resource(a_name, "Texture").to_dict())
 	return list
 
 

--- a/project.godot
+++ b/project.godot
@@ -119,6 +119,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-next/references/property_info.gd"
 }, {
+"base": "Reference",
+"class": "PropertyInfoFactory",
+"language": "GDScript",
+"path": "res://addons/godot-next/references/property_info_factory.gd"
+}, {
 "base": "ResourceCollection",
 "class": "ResourceArray",
 "language": "GDScript",
@@ -197,6 +202,7 @@ _global_script_class_icons={
 "PhysicsLayers": "",
 "ProjectTools": "",
 "PropertyInfo": "",
+"PropertyInfoFactory": "",
 "ResourceArray": "",
 "ResourceCollection": "",
 "ResourceSet": "",


### PR DESCRIPTION
Not sure if this is wanted, but I'd rather avoid using a `SELF_PATH` constant which locks down the path for the script.

This patch also avoid an object leak on PropertyInfo, but that could also be fixed by changing `PropertyInfo` string ocurrences to `Reference` except on `class_name`.