### PR TITLE
Cleared cyclic Behavior reference

### DIFF
--- a/addons/godot-next/resources/behavior.gd
+++ b/addons/godot-next/resources/behavior.gd
@@ -42,7 +42,7 @@ func _on_disable() -> void:
 
 
 # Returns an instance of the stored Behavior resource from the owner.
-func get_behavior(p_type: Script) -> Behavior:
+func get_behavior(p_type: Script) -> Resource:
 	return owner.get_element(p_type)
 
 


### PR DESCRIPTION
Again, this is to avoid object leaks but shouldn't have any negative impact.