### PR TITLE
Update Trail2D to check for target node before setting auto Z-index

### DIFF
--- a/addons/godot-next-cs/2d/Trail2D.cs
+++ b/addons/godot-next-cs/2d/Trail2D.cs
@@ -56,6 +56,7 @@ public class Trail2D : Line2D
             case Node.NotificationParented:
                 if (autoZIndex)
                 {
+                    _target = GetNodeOrNull<Node2D>(targetPath);
                     ZIndex = _target != null ? _target.ZIndex - 1 : 0;
                 }
                 break;

--- a/addons/godot-next-cs/2d/Trail2D.cs
+++ b/addons/godot-next-cs/2d/Trail2D.cs
@@ -46,7 +46,6 @@ public class Trail2D : Line2D
             Gradient.SetColor(0, first);
             Gradient.SetColor(1, DefaultColor);
         }
-        _target = GetNodeOrNull<Node2D>(targetPath);
     }
 
     public override void _Notification(int p_what)


### PR DESCRIPTION
Fixes a bug that can occur with Trail2D when AutoZIndex is enabled and the Trail2D is set to target a parent node. Under those conditions, ZIndex will always be set to 0 (and since `SetAsToplevel` is used in Trail2D it's effectively a global level 0 z-index) instead of the expected Z index of `_target.ZIndex - 1`.

Because the  Trail2D has its `EnterTree()` function called before the parent has been added to the tree, the initial attempt to set `_target` finds nothing and `_target` is null. There is a later check in `_Process` that attempts to set `_target`, but that does not happen until after the auto z-index is set. This PR adds a search for `_target` to the `NotificationParented` handler.

This issue does not happen with trail_2d.gd because in that file the setter for `target_path` is called when `NotificationParented` is received, and the `target_path` setter updates `target`. So I did not change anything with that file.